### PR TITLE
Collectibility thresholds in simulator

### DIFF
--- a/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -292,9 +292,16 @@
                     <div class="quality right-row">
                         <h3>{{'SIMULATOR.Quality' | translate}}</h3>
                         <div class="value-bar">
-                            <mat-progress-bar mode="determinate"
-                                              [value]="100*resultData.simulation.quality/resultData.simulation.recipe.quality"
-                                              color="accent"></mat-progress-bar>
+                            <div class="thresholds-container">
+                                <span *ngFor="let threshold of thresholds"
+                                      [ngStyle]="{left: 100 * threshold / resultData.simulation.recipe.quality + '%'}"
+                                      [matTooltip]="(threshold/10) | number: '1.0-0'"
+                                      class="threshold-marker primary-background"></span>
+
+                                <mat-progress-bar mode="determinate"
+                                                  [value]="100*resultData.simulation.quality/resultData.simulation.recipe.quality"
+                                                  color="accent"></mat-progress-bar>
+                            </div>
                             <span class="value-amount">{{resultData.simulation.quality}}/{{resultData.simulation.recipe.quality}}</span>
                         </div>
                     </div>

--- a/src/app/pages/simulator/components/simulator/simulator.component.scss
+++ b/src/app/pages/simulator/components/simulator/simulator.component.scss
@@ -158,6 +158,18 @@ mat-progress-bar {
                     width: 130px;
                     margin-left: 50px;
                 }
+                .thresholds-container {
+                    position: relative;
+                    width: 100%;
+                    flex: 1 1 auto;
+                    .threshold-marker {
+                        position: absolute;
+                        width: 3px;
+                        height: 30px;
+                        z-index: 10;
+
+                    }
+                }
             }
         }
         .bottom-part {

--- a/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -173,7 +173,7 @@ export class SimulatorComponent implements OnInit, OnDestroy {
     public onsave: EventEmitter<Partial<CraftingRotation>> = new EventEmitter<Partial<CraftingRotation>>();
 
     @Input()
-    public thresholds: number[];
+    public thresholds: number[] = [];
 
     public simulation$: Observable<Simulation>;
 


### PR DESCRIPTION
Add threshold markers and tooltips to the simulator page when item can be a collectible. The default theme is super ugly for this, and I wanna give the tooltips more detail in the future. Will probably forget.