### PR TITLE
Byregot before IG should only show when clvl < rlvl

### DIFF
--- a/apps/client/src/app/pages/simulator/rotation-tips/tips/use-ingenuity-before-byregot.ts
+++ b/apps/client/src/app/pages/simulator/rotation-tips/tips/use-ingenuity-before-byregot.ts
@@ -5,7 +5,8 @@ import {
   ByregotsMiracle,
   Ingenuity,
   IngenuityII,
-  SimulationResult
+  SimulationResult,
+  Tables
 } from '@ffxiv-teamcraft/simulator';
 import { RotationTipType } from '../rotation-tip-type';
 
@@ -23,9 +24,11 @@ export class UseIngenuityBeforeByregot extends RotationTip {
 
   matches(simulationResult: SimulationResult): boolean {
     const simulation = simulationResult.simulation.clone();
+    const clvl = Tables.LEVEL_TABLE[simulation.crafterStats.level] || simulation.crafterStats.level;
     const byregotsIndex = simulation.actions.findIndex(a => a.is(ByregotsBrow) || a.is(ByregotsBlessing) || a.is(ByregotsMiracle));
     return simulation.actions.slice(byregotsIndex).some(a => a.is(Ingenuity) || a.is(Ingenuity))
-      && simulationResult.hqPercent < 100;
+      && simulationResult.hqPercent < 100
+      && clvl < simulation.recipe.rlvl;
   }
 
 }


### PR DESCRIPTION
Topic, IG does nothing for Byregot unless the crafter level is lower than the recipe.

I was unable to test this locally since the router wouldn't let me go to anything other than `/search`, no idea why, so it'd be neat if someone can verify this actually works.