### PR TITLE
fix(ariyala): fix 'hands' slot incorrectly regarded as tool

### DIFF
--- a/apps/client/src/app/pages/lists/list-import-popup/link-parser/ariyala-link-parser.ts
+++ b/apps/client/src/app/pages/lists/list-import-popup/link-parser/ariyala-link-parser.ts
@@ -76,7 +76,7 @@ export class AriyalaLinkParser implements ExternalListLinkParser {
 
         Object.keys(gear.items).forEach((slot, itemIndex) => {
           const item = gear.items[slot];
-          const isTool = slot.indexOf('hand') > -1;
+          const isTool = slot.startsWith('mainhand') || slot.startsWith('offhand');
 
           let quantity = 1;
           if (slot.indexOf('ring') > -1) {


### PR DESCRIPTION
This causes incorrect materia calculations when using the option to assume the same melds accross multiple DoH/DoL jobs.