### PR TITLE
chore: Update node-machina-ffxiv to 2.19.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19413,9 +19413,9 @@
       }
     },
     "node-machina-ffxiv": {
-      "version": "2.19.4",
-      "resolved": "https://registry.npmjs.org/node-machina-ffxiv/-/node-machina-ffxiv-2.19.4.tgz",
-      "integrity": "sha512-xTH140EjO0skY0RA0+yPzCxSJXIMIPzHgQNOXdrMQTdOsiVLFHKPeQMwsM+/MlQAiDUUK0WN0GbFAaJmEhuN7Q==",
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/node-machina-ffxiv/-/node-machina-ffxiv-2.19.5.tgz",
+      "integrity": "sha512-vKdUnOJqy2WmrsK1pGcvRdeRwI/pz6AGfSWxy5ouNX5srn+7fYz/8g5BP5nzYJHMQzeg8cO/pKTz2gtJMpxhGQ==",
       "requires": {
         "jsbi": "^3.1.1",
         "request": "^2.88.0",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "ngx-clipboard": "12.1.0",
     "ngx-color-picker": "^7.5.0",
     "ngx-markdown": "^1.6.0",
-    "node-machina-ffxiv": "^2.19.4",
+    "node-machina-ffxiv": "^2.19.5",
     "papaparse": "^4.6.3",
     "rxjs": "^6.5.3",
     "semver": "^5.4.1",


### PR DESCRIPTION
This patch restores market board upload functionality.