### PR TITLE
Feat/remove cross class setup

### DIFF
--- a/apps/client/src/app/pages/simulator/components/macro-popup/macro-popup.component.html
+++ b/apps/client/src/app/pages/simulator/components/macro-popup/macro-popup.component.html
@@ -38,14 +38,3 @@
     <span *ngFor="let line of macroFragment" class="macro-line">{{line}}<br></span>
   </pre>
 </div>
-<b>{{'SIMULATOR.Cross_class_setup' | translate}}</b>
-<nz-divider></nz-divider>
-<div class="macro">
-  <pre class="macro-fragment">
-    <button [cbContent]="getText(aactionsMacro)" class="copy-macro" ngxClipboard nz-button nzShape="circle"
-            nzSize="small">
-        <i nz-icon nzType="copy"></i>
-    </button>
-    <span *ngFor="let line of aactionsMacro" class="macro-line">{{line}}<br></span>
-  </pre>
-</div>

--- a/apps/client/src/app/pages/simulator/components/macro-popup/macro-popup.component.html
+++ b/apps/client/src/app/pages/simulator/components/macro-popup/macro-popup.component.html
@@ -7,9 +7,6 @@
   <label [(ngModel)]="fixedEcho" (ngModelChange)="generateMacros()" [nzDisabled]="!addEcho" nz-checkbox>
     {{'SIMULATOR.Fixed_notification_number' | translate}}
   </label>
-  <label [(ngModel)]="addConsumables" (ngModelChange)="generateMacros()" nz-checkbox>
-    {{'SIMULATOR.Include_consumables_notification' | translate}}
-  </label>
   <label [(ngModel)]="breakOnReclaim" (ngModelChange)="generateMacros()" nz-checkbox>
     {{'SIMULATOR.Break_on_reclaim' | translate}}
   </label>

--- a/apps/client/src/app/pages/simulator/components/macro-popup/macro-popup.component.ts
+++ b/apps/client/src/app/pages/simulator/components/macro-popup/macro-popup.component.ts
@@ -15,8 +15,6 @@ export class MacroPopupComponent implements OnInit {
 
   public macro: string[][] = [[]];
 
-  public aactionsMacro: string[] = [];
-
   private readonly maxMacroLines = 15;
 
   public addEcho = true;
@@ -52,7 +50,6 @@ export class MacroPopupComponent implements OnInit {
     localStorage.setItem('macros:macrolock', this.macroLock.toString());
     localStorage.setItem('macros:consumables', this.addConsumables.toString());
     this.macro = this.macroLock ? [['/mlock']] : [[]];
-    this.aactionsMacro = ['/aaction clear'];
     let totalLength = 0;
     const reclaimBreakpoint = this.simulation ? this.simulation.clone().run(true).simulation.lastPossibleReclaimStep : -1;
     this.rotation.forEach((action) => {
@@ -66,11 +63,6 @@ export class MacroPopupComponent implements OnInit {
       let actionName = this.i18n.getName(this.l12n.getAction(action.getIds()[0]));
       if (actionName.indexOf(' ') > -1 || this.translator.currentLang === 'ko') {
         actionName = `"${actionName}"`;
-      }
-      if (action.getLevelRequirement().job !== CraftingJob.ANY && action.getLevelRequirement().job !== this.job) {
-        if (this.aactionsMacro.indexOf(`/aaction ${actionName}`) === -1) {
-          this.aactionsMacro.push(`/aaction ${actionName}`);
-        }
       }
 
       macroFragment.push(`/ac ${actionName} <wait.${action.getWaitDuration() + this.extraWait}>`);
@@ -103,21 +95,14 @@ export class MacroPopupComponent implements OnInit {
       }
       this.macro[this.macro.length - 1].push(`/echo Craft finished <se.${seNumber}>`);
     }
-    // 11 not 10 because /aactions clear takes the first line :)
-    if (this.aactionsMacro.length < 11 && this.aactionsMacro.indexOf(`/aaction "${this.i18n.getName(this.l12n.getAction(new HastyTouch().getIds()[0]))}"`) === -1) {
-      this.aactionsMacro.push(`/aaction "${this.i18n.getName(this.l12n.getAction(new HastyTouch().getIds()[0]))}"`);
-    }
-    if (this.aactionsMacro.length > 11) {
-      this.tooManyAactions = true;
-    }
-    if (this.aactionsMacro.length > 0) {
-      this.aactionsMacro.push('/echo Cross class setup finished <se.4>');
-    }
-
+    
+    /* Without the additional actions macro there is nothing to add the consumable macro to
+    
     const consumablesNotification = this.getConsumablesNotification();
     if (consumablesNotification !== undefined) {
       this.aactionsMacro.push(consumablesNotification);
     }
+    */
   }
 
   /**


### PR DESCRIPTION
Removed the cross-class setup section of the macro creator.

Removed the consumable notification checkbox, at least temporarily, as there is currently no way to have the notification without the additional actions macro.