### PR TITLE
chore: Update node-machina-ffxiv to 2.19.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19413,9 +19413,9 @@
       }
     },
     "node-machina-ffxiv": {
-      "version": "2.19.7",
-      "resolved": "https://registry.npmjs.org/node-machina-ffxiv/-/node-machina-ffxiv-2.19.7.tgz",
-      "integrity": "sha512-lDZOBoPZ4wh4N5KCXQl4khg6bdC178Co3p1dZd/sjNU2FIcSUjZZPvwR4dXy2Ff0pVzKhdE8Irfi0Yn431p9xA==",
+      "version": "2.19.8",
+      "resolved": "https://registry.npmjs.org/node-machina-ffxiv/-/node-machina-ffxiv-2.19.8.tgz",
+      "integrity": "sha512-m5J6WEVlE3UZA9+mJHSK5blamCGWIXNEqMrBzv6olW7KX/0T+4dNTMD5CsCP/5AjtihHe8+iO/Rq1wY9JGWHIg==",
       "requires": {
         "jsbi": "^3.1.1",
         "request": "^2.88.0",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "ngx-clipboard": "12.1.0",
     "ngx-color-picker": "^7.5.0",
     "ngx-markdown": "^1.6.0",
-    "node-machina-ffxiv": "^2.19.7",
+    "node-machina-ffxiv": "^2.19.8",
     "papaparse": "^4.6.3",
     "rxjs": "^6.5.3",
     "semver": "^5.4.1",


### PR DESCRIPTION
This adds a clone of itemCatalogId to match the corresponding listing packet, and fixing history upload validity.