### PR TITLE
feat(search): Ignore HQ and Collectable symbols in search

### DIFF
--- a/apps/client/src/app/core/api/data.service.ts
+++ b/apps/client/src/app/core/api/data.service.ts
@@ -127,6 +127,9 @@ export class DataService {
    * @returns {Observable<Recipe[]>}
    */
   public searchItem(query: string, filters: SearchFilter[], onlyCraftable: boolean, sort: [string, 'asc' | 'desc'] = [null, 'desc']): Observable<SearchResult[]> {
+    // Filter HQ and Collectable Symbols from search
+    query = query.replace(/[\ue03a-\ue03d]/g, "");
+
     let lang = this.i18n.currentLang;
     const isKoOrZh = ['ko', 'zh'].indexOf(this.i18n.currentLang.toLowerCase()) > -1 && query.length > 0;
     if (isKoOrZh) {


### PR DESCRIPTION
Allows for copy item name direct from game to search box.