### PR TITLE
chore: add high memory start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "scripts": {
     "ng-high-memory": "node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng",
     "ng": "ng",
+    "start-high-memory": "node ./tools/build/prebuild.js && ng-high-memory serve --project=client",
     "start": "node ./tools/build/prebuild.js && ng serve --project=client",
     "build:watch": "node ./tools/build/prebuild.js && npm run ng-high-memory build -- --project=client --watch --configuration=electron-dev",
     "build:prod": "node ./tools/build/prebuild.js && npm run ng-high-memory build -- --project=client --prod --no-progress",


### PR DESCRIPTION
too lazy to type `npm run ng-high-memory serve --project=client` ;)

