### PR TITLE
fix: Correct world ID not changing for data uploads when appropriate

### DIFF
--- a/apps/client/src/app/core/api/universalis.service.ts
+++ b/apps/client/src/app/core/api/universalis.service.ts
@@ -19,9 +19,8 @@ export class UniversalisService {
     shareReplay(1)
   );
 
-  private worldId$: Observable<number> = this.authFacade.user$.pipe(
-    map(user => user.world),
-    filter(world => world !== undefined),
+  private worldId$: Observable<number> = this.ipc.worldId$.pipe(
+    filter(worldId => worldId !== undefined),
     distinctUntilChanged(),
     shareReplay(1)
   );


### PR DESCRIPTION
Just a matter of putting the packet information where it needs to go