### PR TITLE
fix(search): Fix recipe search not showing any items in some cases

### DIFF
--- a/apps/client/src/app/core/api/data.service.ts
+++ b/apps/client/src/app/core/api/data.service.ts
@@ -179,6 +179,14 @@ export class DataService {
         }];
       }));
 
+    if (onlyCraftable){
+      xivapiFilters.push({
+        column: "Recipes.ClassJobID",
+        operator: ">",
+        value: 0
+      });
+    }
+
     const searchOptions: XivapiSearchOptions = {
       indexes: [SearchIndex.ITEM],
       string: query,


### PR DESCRIPTION
Check that a recipe exists, and it craftable by any class, when searching for a recipe.