### PR TITLE
chore: move history off debounce; fix zero-listing-case

### DIFF
--- a/apps/client/src/app/core/api/universalis.service.ts
+++ b/apps/client/src/app/core/api/universalis.service.ts
@@ -122,6 +122,11 @@ export class UniversalisService {
   }
 
   public initCapture(): void {
+    this.ipc.marketBoardSearchResult$.subscribe((searchResults) => {
+      if (this.settings.enableUniversalisSourcing) {
+        this.handleMarketboardSearchResult(searchResults);
+      }
+    });
     this.ipc.marketboardListingCount$
       .pipe(
         switchMap(packet => {
@@ -133,16 +138,11 @@ export class UniversalisService {
           this.handleMarketboardListingPackets(listings);
         }
       });
-    this.ipc.marketboardListingHistory$
-      .pipe(
-        buffer(this.ipc.marketboardListingHistory$.pipe(debounceTime(2000))),
-        filter(packets => packets.length > 0)
-      )
-      .subscribe(listings => {
-        if (this.settings.enableUniversalisSourcing) {
-          this.handleMarketboardListingHistoryPackets(listings);
-        }
-      });
+    this.ipc.marketboardListingHistory$.subscribe(packet => {
+      if (this.settings.enableUniversalisSourcing) {
+        this.handleMarketboardListingHistory(packet);
+      }
+    });
     this.ipc.marketTaxRatePackets$.subscribe(packet => {
       if (this.settings.enableUniversalisSourcing) {
         this.uploadMarketTaxRates(packet);
@@ -153,6 +153,29 @@ export class UniversalisService {
         this.uploadCid(packet);
       }
     });
+  }
+
+  public handleMarketboardSearchResult(packet: any): void {
+    combineLatest([this.cid$, this.worldId$]).pipe(
+      first(),
+      switchMap(([cid, worldId]) => {
+        const data = {
+          worldID: worldId,
+          uploaderID: cid,
+          itemIDs: _.compact(packet.items.map((item) => {
+            if (item.itemCatalogID && !item.quantity) {
+              return item.itemCatalogID;
+            }
+          })),
+          op: {
+            listings: -1
+          }
+        };
+        return this.http.post('https://us-central1-ffxivteamcraft.cloudfunctions.net/universalis-publisher', data, {
+          headers: new HttpHeaders().append('Content-Type', 'application/json')
+        });
+      })
+    ).subscribe();
   }
 
   public handleMarketboardListingPackets(packets: any[]): void {
@@ -198,31 +221,24 @@ export class UniversalisService {
     ).subscribe();
   }
 
-  public handleMarketboardListingHistoryPackets(packets: any[]): void {
+  public handleMarketboardListingHistory(packet: any): void {
     combineLatest([this.cid$, this.worldId$]).pipe(
       first(),
       switchMap(([cid, worldId]) => {
         const data = {
           worldID: worldId,
-          itemID: packets[0].itemID,
+          itemID: packet.itemID,
           uploaderID: cid,
-          entries: packets.reduce((listings, packet) => {
-            return [
-              ...listings,
-              ...packet.listings
-                .map((item) => {
-                  return {
-                    hq: item.hq,
-                    pricePerUnit: item.salePrice,
-                    quantity: item.quantity,
-                    total: item.salePrice * item.quantity,
-                    buyerName: item.buyerName,
-                    onMannequin: item.onMannequin,
-                    timestamp: item.purchaseTime
-                  };
-                })
-            ];
-          }, [])
+          entries: packet.listings.map((entry) => {
+            return {
+              hq: entry.hq,
+              pricePerUnit: entry.salePrice,
+              quantity: entry.quantity,
+              buyerName: entry.buyerName,
+              onMannequin: entry.onMannequin,
+              timestamp: entry.purchaseTime
+            };
+          })
         };
         return this.http.post('https://us-central1-ffxivteamcraft.cloudfunctions.net/universalis-publisher', data, {
           headers: new HttpHeaders().append('Content-Type', 'application/json')

--- a/apps/client/src/app/core/electron/ipc.service.ts
+++ b/apps/client/src/app/core/electron/ipc.service.ts
@@ -36,6 +36,10 @@ export class IpcService {
     return this.packets$.pipe(ofPacketType('marketTaxRates'));
   }
 
+  public get marketBoardSearchResult$(): Observable<any> {
+    return this.packets$.pipe(ofPacketType('marketBoardSearchResult'));
+  }
+
   public get marketboardListingCount$(): Observable<any> {
     return this.packets$.pipe(ofPacketType('marketBoardItemListingCount'));
   }

--- a/desktop/machina.js
+++ b/desktop/machina.js
@@ -54,6 +54,7 @@ module.exports.start = function(win, config, verbose, winpcap) {
         'marketBoardItemListingCount',
         'marketBoardItemListing',
         'marketBoardItemListingHistory',
+        'marketBoardSearchResult',
         'marketTaxRates',
         'playerSetup',
         'playerSpawn',


### PR DESCRIPTION
The history data is only a single packet, so it doesn't need a debounce. 
To handle a packet having no listings, the client needs to send an erase 
op for these items. This information is obtained from the search result 
packet.