### PR TITLE
Fix(db): Several link fixes

### DIFF
--- a/apps/client/src/app/pages/db/item/item.component.ts
+++ b/apps/client/src/app/pages/db/item/item.component.ts
@@ -288,11 +288,12 @@ export class ItemComponent extends TeamcraftPageComponent {
           });
         }
         const gardening = getItemSource(listRow, DataType.GARDENING);
-        if (gardening) {
+        console.log(gardening);
+        if (Number.isInteger(gardening)) {
           links.push({
             title: 'FFXIV Gardening',
             icon: './assets/icons/Gardening.png',
-            url: `https://${this.translate.currentLang === 'en' ? 'www' : this.translate.currentLang}.ffxivgardening.com/seed-details.php?SeedID=${gardening}`
+            url: `http://${this.translate.currentLang === 'en' ? 'www' : this.translate.currentLang}.ffxivgardening.com/seed-details.php?SeedID=${gardening}`
           });
         }
         if (xivapiItem.ItemActionTargetID === 1389) {

--- a/apps/client/src/app/pages/db/item/item.component.ts
+++ b/apps/client/src/app/pages/db/item/item.component.ts
@@ -282,9 +282,9 @@ export class ItemComponent extends TeamcraftPageComponent {
         ];
         if (!xivapiItem.IsUntradable) {
           links.push({
-            title: 'Mogboard',
-            icon: 'https://mogboard.com/i/mog/mog.png',
-            url: `https://mogboard.com/market/${xivapiItem.ID}`
+            title: 'Universalis',
+            icon: 'https://universalis.app/i/universalis/universalis.png',
+            url: `https://universalis.app/market/${xivapiItem.ID}`
           });
         }
         const gardening = getItemSource(listRow, DataType.GARDENING);

--- a/apps/client/src/app/pages/db/item/item.component.ts
+++ b/apps/client/src/app/pages/db/item/item.component.ts
@@ -288,7 +288,6 @@ export class ItemComponent extends TeamcraftPageComponent {
           });
         }
         const gardening = getItemSource(listRow, DataType.GARDENING);
-        console.log(gardening);
         if (Number.isInteger(gardening)) {
           links.push({
             title: 'FFXIV Gardening',


### PR DESCRIPTION
- Fixed gardening link refusing to connect, ffxiv gardening no longer supports HTTPS after switching webhosts. 
- Fixed gardening link showing up on item pages for items that do not come from gardening.
- Changed outdated mogboard link to universalis