### PR TITLE
chore: Update node-machina-ffxiv to 2.31.23

### DIFF
--- a/apps/client/src/app/core/data-reporting/fishing-reporter.ts
+++ b/apps/client/src/app/core/data-reporting/fishing-reporter.ts
@@ -155,7 +155,7 @@ export class FishingReporter implements DataReporter {
     );
 
     const actionTimeline$ = packets$.pipe(
-      ofPacketType('eventUnk0'),
+      ofPacketType('eventPlay4'),
       map(packet => {
         return actionTimeline[packet.actionTimeline.toString()];
       }),
@@ -163,7 +163,7 @@ export class FishingReporter implements DataReporter {
     );
 
     const mooch$ = packets$.pipe(
-      ofPacketType('eventUnk1'),
+      ofPacketType('eventPlay8'),
       filter(packet => packet.actionTimeline === 257),
       map(packet => {
         return packet.param1 === 1121;
@@ -172,7 +172,7 @@ export class FishingReporter implements DataReporter {
 
     const misses$ = combineLatest([
       packets$.pipe(
-        ofPacketType('eventUnk1'),
+        ofPacketType('eventPlay8'),
         map(packet => {
           return {
             animation: packet.actionTimeline,

--- a/desktop/machina.js
+++ b/desktop/machina.js
@@ -67,8 +67,8 @@ module.exports.start = function(win, config, verbose, winpcap) {
         'eventPlay',
         'eventStart',
         'eventFinish',
-        'eventUnk0',
-        'eventUnk1',
+        'eventPlay4',
+        'eventPlay8',
         'updatePositionHandler',
         'actorControlSelf',
         'useMooch'

--- a/package-lock.json
+++ b/package-lock.json
@@ -19593,9 +19593,9 @@
       }
     },
     "node-machina-ffxiv": {
-      "version": "2.31.23",
-      "resolved": "https://registry.npmjs.org/node-machina-ffxiv/-/node-machina-ffxiv-2.31.23.tgz",
-      "integrity": "sha512-yRSK6mkJcEIeOZFyPsvV42lJe89IAGIQt6LLXLtfIg+vC0mwAg+6efsMNHe8eluqR66RL11t71WgRsDCjLSFNw==",
+      "version": "2.31.24",
+      "resolved": "https://registry.npmjs.org/node-machina-ffxiv/-/node-machina-ffxiv-2.31.24.tgz",
+      "integrity": "sha512-tihZ+8q2Lle5zwsYaZFK6IZoyS2grWHHt2jEfNT6fZ8lynMdo8CXl8w6JnP2K9oXRywhZXJrXSW2FTVmz5FEhQ==",
       "requires": {
         "jsbi": "^3.1.1",
         "request": "^2.88.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19593,9 +19593,9 @@
       }
     },
     "node-machina-ffxiv": {
-      "version": "2.30.4",
-      "resolved": "https://registry.npmjs.org/node-machina-ffxiv/-/node-machina-ffxiv-2.30.4.tgz",
-      "integrity": "sha512-Hv0fPuvuHEkg4wtIYIDKis/fQ/uoUZjIqx8yjWdNp19gfj9p9ZE8WFma6IPuOx2zlOFW0GwYajtN0/swQ9LZ9w==",
+      "version": "2.31.23",
+      "resolved": "https://registry.npmjs.org/node-machina-ffxiv/-/node-machina-ffxiv-2.31.23.tgz",
+      "integrity": "sha512-yRSK6mkJcEIeOZFyPsvV42lJe89IAGIQt6LLXLtfIg+vC0mwAg+6efsMNHe8eluqR66RL11t71WgRsDCjLSFNw==",
       "requires": {
         "jsbi": "^3.1.1",
         "request": "^2.88.0",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "ngx-clipboard": "12.1.0",
     "ngx-color-picker": "^7.5.0",
     "ngx-markdown": "^1.6.0",
-    "node-machina-ffxiv": "^2.31.23",
+    "node-machina-ffxiv": "^2.31.24",
     "papaparse": "^4.6.3",
     "rxjs": "^6.5.3",
     "semver": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "ngx-clipboard": "12.1.0",
     "ngx-color-picker": "^7.5.0",
     "ngx-markdown": "^1.6.0",
-    "node-machina-ffxiv": "^2.30.4",
+    "node-machina-ffxiv": "^2.31.23",
     "papaparse": "^4.6.3",
     "rxjs": "^6.5.3",
     "semver": "^5.4.1",


### PR DESCRIPTION
This seems to fix the hanging on zone changes, and has all of Sapphire's latest opcodes as well. EventUnk0 and EventUnk1 have been renamed to EventPlay#.

This should all be tested to make sure the hanging fix works for everyone affected and that no more opcodes are missing.