### PR TITLE
Added "Consolidate Stacks" Inventory Optimizer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [{
+    "name": "Launch Edge",
+    "type": "edge",
+    "request": "launch",
+    "version": "beta",
+    "url": "http://localhost:4200",
+    "webRoot": "${workspaceFolder}/apps/client"
+  }]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [{
+    "label": "npm start",
+    "type": "npm",
+    "script": "start",
+    "problemMatcher": [
+      "$tsc"
+    ]
+  }]
+}

--- a/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer.module.ts
+++ b/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer.module.ts
@@ -20,6 +20,7 @@ import { FormsModule } from '@angular/forms';
 import { ClipboardModule } from 'ngx-clipboard';
 import { HasTooFew } from './optimizations/has-too-few';
 import { LazyDataService } from '../../core/data/lazy-data.service';
+import { ConsolidateStacks } from './optimizations/consolidate-stacks';
 
 const optimisations: Provider[] = [
   {
@@ -38,6 +39,12 @@ const optimisations: Provider[] = [
     useClass: HasTooFew,
     multi: true,
     deps: [LazyDataService]
+  },
+  {
+    provide: INVENTORY_OPTIMIZER,
+    useClass: ConsolidateStacks,
+    multi: true,
+    deps: [TranslateService, InventoryFacade, LazyDataService]
   }
 ];
 

--- a/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.html
+++ b/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.html
@@ -13,25 +13,39 @@
   <nz-spin [nzSpinning]="loading">
     <div fxLayout="column" fxLayoutGap="10px">
       <nz-collapse *ngFor="let optimization of optimizations; trackBy: trackByTip">
-        <nz-collapse-panel [nzHeader]="header" [nzExtra]="optimization.type === 'HAS_TOO_FEW' ? extraTooFewTpl : null">
+        <nz-collapse-panel [nzHeader]="header" [nzExtra]="extraTpl">
           <ng-template #header>
             {{'INVENTORY_OPTIMIZER.' + optimization.type + '.Title' | translate}} ({{optimization.totalLength}})
           </ng-template>
-          <ng-template #extraTooFewTpl>
-            <nz-input-group nzSearch nzSize="small" [nzAddOnAfter]="suffixButton" [nzAddOnBefore]="nzAddOnBefore">
-              <input type="number" nz-input min="1" [ngModel]="stackSizeThreshold" #stackSizeInput
-                     (click)="$event.stopPropagation()"/>
-            </nz-input-group>
-            <ng-template #suffixButton>
-              <button nz-button
-                      (click)="$event.stopPropagation(); stackSizeThreshold = +stackSizeInput.value"
-                      nzType="primary"
-                      nzSize="small"
-                      nzSearch>{{'COMMON.Apply' | translate}}</button>
-            </ng-template>
-            <ng-template #nzAddOnBefore>
-              {{'INVENTORY_OPTIMIZER.HAS_TOO_FEW.Threshold_amount' | translate}}
-            </ng-template>
+          <ng-template #extraTpl>
+            <ng-container [ngSwitch]="optimization.type">
+              <ng-container *ngSwitchCase="'HAS_TOO_FEW'">
+                <nz-input-group nzSearch nzSize="small" [nzAddOnAfter]="suffixButton" [nzAddOnBefore]="nzAddOnBefore">
+                  <input type="number" nz-input min="1" [ngModel]="stackSizeThreshold" #stackSizeInput
+                         (click)="$event.stopPropagation()"/>
+                </nz-input-group>
+                <ng-template #suffixButton>
+                  <button nz-button
+                          (click)="$event.stopPropagation(); stackSizeThreshold = +stackSizeInput.value"
+                          nzType="primary"
+                          nzSize="small"
+                          nzSearch>{{'COMMON.Apply' | translate}}</button>
+                </ng-template>
+                <ng-template #nzAddOnBefore>
+                  {{'INVENTORY_OPTIMIZER.HAS_TOO_FEW.Threshold_amount' | translate}}
+                </ng-template>
+              </ng-container>
+              <ng-container *ngSwitchCase="'CONSOLIDATE_STACKS'">
+                <span>{{'INVENTORY_OPTIMIZER.CONSOLIDATE_STACKS.Filter' | translate}}</span>
+                <nz-select nzAllowClear
+                           nzSize="small"
+                           (click)="$event.stopPropagation();"
+                           [nzPlaceHolder]="'INVENTORY_OPTIMIZER.CONSOLIDATE_STACKS.Placeholder' | translate"
+                           [(ngModel)]="selectedExpansion">
+                  <nz-option *ngFor="let e of getExpansions()" [nzValue]="e.version" [nzLabel]="e.name"></nz-option>
+                </nz-select>
+              </ng-container>
+            </ng-container>
           </ng-template>
           <nz-collapse>
             <ng-container *ngFor="let container of optimization.entries; trackBy: trackByEntry">

--- a/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.less
+++ b/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.less
@@ -1,3 +1,8 @@
 :host ::ng-deep .ant-collapse-header {
   padding: 12px 12px 12px 40px !important;
 }
+
+nz-select {
+  margin-right: 8px;
+  width: 200px;
+}

--- a/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.ts
+++ b/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.ts
@@ -13,6 +13,7 @@ import { NzMessageService } from 'ng-zorro-antd';
 import { TranslateService } from '@ngx-translate/core';
 import { HasTooFew } from '../optimizations/has-too-few';
 import { ListRow } from '../../../modules/list/model/list-row';
+import { ConsolidateStacks } from '../optimizations/consolidate-stacks';
 
 @Component({
   selector: 'app-inventory-optimizer',
@@ -119,12 +120,37 @@ export class InventoryOptimizerComponent {
   }
 
   constructor(private inventoryFacade: InventoryFacade,
-              @Inject(INVENTORY_OPTIMIZER) private optimizers: InventoryOptimizer[],
-              private lazyData: LazyDataService, private message: NzMessageService, private translate: TranslateService) {
+    @Inject(INVENTORY_OPTIMIZER) private optimizers: InventoryOptimizer[],
+    private lazyData: LazyDataService, private message: NzMessageService, private translate: TranslateService) {
   }
 
   private getContainerName(item: InventoryItem): string {
     return item.retainerName || this.inventoryFacade.getContainerName(item.containerId);
+  }
+
+  public getExpansions(): string[] {
+    const expansions: any[] = this.lazyData.patches.map(p => {
+      return { name: p.ExName, version: p.ExVersion }
+    });
+
+    return uniqBy(expansions, 'name');
+  }
+
+  public get selectedExpansion(): number {
+    const selection = localStorage.getItem(ConsolidateStacks.SELECTION_KEY);
+    return selection ? +selection : null;
+  }
+
+  public set selectedExpansion(selection: number) {
+    if (selection !== null) {
+      localStorage.setItem(ConsolidateStacks.SELECTION_KEY, selection.toString());
+    }
+    else {
+      localStorage.removeItem(ConsolidateStacks.SELECTION_KEY);
+    }
+
+    this.loading = true;
+    this.resultsReloader$.next(null);
   }
 
   nameCopied(key: string, args?: any): void {

--- a/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.ts
+++ b/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.ts
@@ -57,8 +57,7 @@ export class InventoryOptimizerComponent {
                     .value(),
                   totalLength: uniqBy(entries, 'item.itemId').length
                 };
-              })
-              .filter(res => res.entries.length > 0);
+              });
           })
         )),
         tap(() => this.loading = false)
@@ -95,7 +94,7 @@ export class InventoryOptimizerComponent {
             });
             opt.totalLength = uniq(total).length;
             return opt;
-          }).filter(opt => opt.totalLength > 0);
+          });
         })
       );
     })

--- a/apps/client/src/app/pages/inventory-optimizer/optimizations/consolidate-stacks.ts
+++ b/apps/client/src/app/pages/inventory-optimizer/optimizations/consolidate-stacks.ts
@@ -1,0 +1,79 @@
+import { InventoryOptimizer } from './inventory-optimizer';
+import { InventoryItem } from '../../../model/user/inventory/inventory-item';
+import { UserInventory } from '../../../model/user/inventory/user-inventory';
+import { ListRow } from '../../../modules/list/model/list-row';
+import { TranslateService } from '@ngx-translate/core';
+import { InventoryFacade } from '../../../modules/inventory/+state/inventory.facade';
+import { LazyDataService } from '../../../core/data/lazy-data.service';
+import { Memoized } from '../../../core/decorators/memoized';
+
+export class ConsolidateStacks extends InventoryOptimizer {
+
+  static SELECTION_KEY = 'optimizer:consolidate-stacks:selection';
+
+  constructor(private translate: TranslateService, private inventoryFacade: InventoryFacade, private lazyData: LazyDataService) {
+    super();
+  }
+
+  @Memoized()
+  getPatch(id: number): any {
+    return this.lazyData.patches.find(p => p.ID === id);
+  }
+
+  itemInExpansion(itemId: number, expansion: number): boolean {
+    // If the specified item does not have a patch associated with it, we do not filter it.
+    const itemPatch = this.lazyData.data.itemPatch[itemId];
+    if (itemPatch === null) {
+      return true;
+    }
+
+    // If no patch is defined for this patch that the item is assigned to, do not filter it.
+    const patch = this.getPatch(itemPatch);
+    if (patch === null) {
+      return true;
+    }
+
+    return patch.ExVersion <= expansion;
+  }
+
+  protected _getOptimization(item: InventoryItem, inventory: UserInventory, data: ListRow): { [p: string]: number | string } | null {
+    const expansion = localStorage.getItem(ConsolidateStacks.SELECTION_KEY);
+
+    // After filtering is completed, this container will have a list of HQ-only items that need to
+    // be merged with a separate type-same NQ stack.
+    const toConsolidate = inventory.toArray()
+      .filter(i => {
+        // Implementation Note:
+        //
+        // Majority of items will be filtered out because the IDs do not match. Make the `itemId`
+        // comparison the first condition we check for performance reasons. This means we spend less
+        // time iterating the IGNORED_CONTAINERS container. In general, comparisons are performed
+        // from least-expensive to most-expensive (algorithmically).
+        return i.itemId === item.itemId
+          // If we have no expansion selected to filter on, treat *all* items as "in expansion"
+          && (expansion === null || this.itemInExpansion(item.itemId, +expansion))
+          && item.hq === false
+          && i.hq === true
+          && i.spiritBond === 0
+          && !InventoryOptimizer.inSameSlot(i, item)
+          && item.quantity + i.quantity < this.lazyData.data.stackSizes[i.itemId]
+          && InventoryOptimizer.IGNORED_CONTAINERS.indexOf(i.containerId) === -1;
+      });
+
+    if (toConsolidate.length === 0) {
+      return null;
+    }
+
+    return {
+      containers: toConsolidate.map(dupe => {
+        return dupe.retainerName ||
+          this.translate.instant(`INVENTORY.BAG.${this.inventoryFacade.getContainerName(dupe.containerId)}`);
+      }).join(', ')
+    };
+  }
+
+  getId(): string {
+    return 'CONSOLIDATE_STACKS';
+  }
+
+}

--- a/apps/client/src/app/pages/inventory-optimizer/optimizations/duplicates.ts
+++ b/apps/client/src/app/pages/inventory-optimizer/optimizations/duplicates.ts
@@ -21,7 +21,7 @@ export class Duplicates extends InventoryOptimizer {
         return i.itemId === item.itemId
           && i.hq === item.hq
           && i.spiritBond === 0
-          && i.slot !== item.slot
+          && !InventoryOptimizer.inSameSlot(i, item)
           && item.quantity + i.quantity < this.lazyData.data.stackSizes[i.itemId];
       });
     if (dupes.length > 0) {

--- a/apps/client/src/app/pages/inventory-optimizer/optimizations/inventory-optimizer.ts
+++ b/apps/client/src/app/pages/inventory-optimizer/optimizations/inventory-optimizer.ts
@@ -30,6 +30,12 @@ export abstract class InventoryOptimizer {
     ContainerType.FreeCompanyGil
   ];
 
+  /// Compare two InventoryItem objects to determine whether they consume the same slot in the same
+  /// container.
+  protected static inSameSlot(source: InventoryItem, target: InventoryItem): boolean {
+    return source.slot === target.slot && source.containerId === target.containerId;
+  }
+
   public getOptimization(item: InventoryItem, inventory: UserInventory, extracts: ListRow[]): { [p: string]: number | string } | null {
     if (InventoryOptimizer.IGNORED_CONTAINERS.indexOf(item.containerId) > -1) {
       return null;

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -1708,6 +1708,12 @@
       "Title": "Items that you have in very small stacks",
       "Message": "You only have {{amount}} of this item, is it worth keeping them?",
       "Threshold_amount": "Threshold value"
+    },
+    "CONSOLIDATE_STACKS": {
+      "Title": "HQ stacks of items that can have their quality lowered",
+      "Message": "Combine with NQ stack in: {{containers}}",
+      "Filter": "Only show materials up to: ",
+      "Placeholder": "Pick Expansion"
     }
   },
   "VERSION_LOCK": {


### PR DESCRIPTION
A new inventory optimizer that will suggest high-quality (HQ) stacks of
items that can have their quality lowered so that it can be joined with
an existing normal-quality (NQ) stack of that same type of item. This is
a very reliable way to free up inventory slots.

Because users may not want all stacks of items suggested, filtering is
provided by expansion. For example, if a user wants all items in
Heavensward and below suggested (Heavensward + A Realm Reborn), they
will select "Heavensward" from the filter select box. Items with HQ and
NQ stacks from Stormblood and Shadowbringers will *not* be selected in
this case because they are filtered out. You can also clear the filter
box (so it says "Pick Expansion") which completely disables filtering,
showing all available items in your inventory to which the optimization
applies.

In general, if item database information is incomplete, an item does not
get filtered even if it may have been otherwise. Examples:

* The specified item does not have an assigned patch.
* A patch to which an item is assigned is not defined.

Other changes:

* Debugging support for VS Code

* Don't ignore dupes at same slot in diff inventory

  The duplicate optimizer no longer ignores items in the same slot but in
different inventories. The condition used to check only if the slot ID
was the same. Now in addition to that, the inventory ID must also match.

* Optimizer panels no longer hide when empty

  For optimizer panels with interactive input fields on them, if they are
hidden due to the filters being too strict, that makes it so that the
user will not be able to alter the values.

  To avoid this, the panels are no longer hidden if they are empty. The
user can refer to the count presented on the panel text itself to
determine if they should ignore it or not (e.g. zero items).

* Add gitattributes
