### PR TITLE
Gearsets: Fix materia change detection

### DIFF
--- a/apps/client/src/app/pages/gearset/gearset-editor/gearset-editor.component.ts
+++ b/apps/client/src/app/pages/gearset/gearset-editor/gearset-editor.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { GearsetsFacade } from '../../../modules/gearsets/+state/gearsets.facade';
 import { distinctUntilChanged, filter, first, map, switchMap, takeUntil, tap } from 'rxjs/operators';
@@ -298,7 +298,8 @@ export class GearsetEditorComponent extends TeamcraftComponent implements OnInit
               private l12n: LocalizedDataService, private lazyData: LazyDataService,
               public translate: TranslateService, private dialog: NzModalService,
               private  materiasService: MateriaService, private statsService: StatsService,
-              private i18n: I18nToolsService, private ipc: IpcService, private router: Router) {
+              private i18n: I18nToolsService, private ipc: IpcService, private router: Router,
+              private cd: ChangeDetectorRef) {
     super();
     this.permissionLevel$.pipe(
       takeUntil(this.onDestroy$)
@@ -434,13 +435,14 @@ export class GearsetEditorComponent extends TeamcraftComponent implements OnInit
       },
       nzFooter: null
     }).afterClose
-      .subscribe((res) => {
-        if (res && res.materias.some(m => m > 0)) {
+      .subscribe(res => {
+        if (res) {
           this.materiaCache = {
             ...this.materiaCache,
             [`${res.itemId}:${propertyName}`]: res.materias
           };
           equipmentPiece.materias = [...res.materias];
+          this.cd.detectChanges();
         }
         if (res && gearset[propertyName] && gearset[propertyName].itemId === res.itemId) {
           this.setGearsetPiece(gearset, propertyName, { ...res });


### PR DESCRIPTION
Two issues addressed:

1. Removal of last materia in a piece of equipment was ignored. So that
   materia could never be removed.
2. When adding or removing a materia, the Gearset Editor view was not
   dynamically updating.