### PR TITLE
chore(desktop): update retainers tracking for KR/CN players

### DIFF
--- a/apps/client/src/app/core/electron/machina.service.ts
+++ b/apps/client/src/app/core/electron/machina.service.ts
@@ -17,8 +17,6 @@ import { territories } from '../data/sources/territories';
 import { debounceBufferTime } from '../rxjs/debounce-buffer-time';
 import { ofPacketSubType } from '../rxjs/of-packet-subtype';
 import * as firebase from 'firebase/app';
-import { SettingsService } from '../../modules/settings/settings.service';
-import { Region } from '../../modules/settings/region.enum';
 
 @Injectable({
   providedIn: 'root'
@@ -37,8 +35,8 @@ export class MachinaService {
     bufferCount(10)
   );
 
-  private retainerSpawns$: Observable<string> = combineLatest([this.retainerInformations$, this.ipc.npcSpawnPackets$, this.settings.region$]).pipe(
-    map(([retainers, spawn, region]) => {
+  private retainerSpawns$: Observable<string> = combineLatest([this.retainerInformations$, this.ipc.npcSpawnPackets$]).pipe(
+    map(([retainers, spawn]) => {
       let name: string = spawn.name;
       const splitForCheck = name.split('');
       // If there's a char below SPACE (\u0020), it's simply not possible for this name to be valid, let's strip the invalid part
@@ -48,14 +46,9 @@ export class MachinaService {
       if (borkedData > -1) {
         name = name.substring(borkedData);
       }
-      return [retainers, name, region, spawn];
+      return [retainers, name];
     }),
-    filter(([retainers, name, region, spawn]: [any[], string, Region, any]) => {
-      if (region === Region.Global) {
-        return name.length > 0 && retainers.some(retainer => retainer.name === name);
-      }
-      return spawn.modelType === 0x0A;
-    }),
+    filter(([retainers, name]: [any[], string]) => name.length > 0 && retainers.some(retainer => retainer.name === name)),
     map(([, name]) => {
       return name;
     }),
@@ -65,8 +58,7 @@ export class MachinaService {
 
   constructor(private ipc: IpcService, private userInventoryService: InventoryFacade,
               private universalis: UniversalisService, private authFacade: AuthFacade,
-              private listsFacade: ListsFacade, private eorzeaFacade: EorzeaFacade,
-              private settings: SettingsService) {
+              private listsFacade: ListsFacade, private eorzeaFacade: EorzeaFacade) {
     this.inventory$ = this.userInventoryService.inventory$.pipe(
       distinctUntilChanged((a, b) => {
         return _.isEqual(a, b);


### PR DESCRIPTION
I checked that the opcode `RetainerInformation` works properly.
CN opcodes also have it.

It needs node-machina-ffxiv 2.32.7
Idk how to edit package.json 😅

I just modified from this commit https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/e7f25d01226715037a08432a5b63cf4e08b96def
I didn't touch `settings.service.ts` file, also I don't know... 

I don't know if I saved your trouble, but please do the rest! ❤️ 