### PR TITLE
fix(ux): fixed crafting level showing on item page

### DIFF
--- a/apps/client/src/app/pages/db/item/item.component.html
+++ b/apps/client/src/app/pages/db/item/item.component.html
@@ -181,7 +181,7 @@
                                fxLayoutGap="5px">
                             <img alt="" class="smaller-img-icon"
                                  src="https://garlandtools.org/db/images/{{(recipe.job | jobAbbr)?.en}}.png">
-                            <div>lvl {{recipe.level}} {{recipe.stars | ingameStars}}<span *ngIf="!last">,</span></div>
+                            <div>lvl {{recipe.lvl}} {{recipe.stars | ingameStars}}<span *ngIf="!last">,</span></div>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
Fixes an issue on item pages where crafting level wasn't showing up.

Example: https://ffxivteamcraft.com/db/en/item/28718/Sublime-Solution
Scroll to the bottom in the "Used For" section, it only shows stars, not actual crafting level.