### PR TITLE
Fix consolidate stacks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,27 +1,14 @@
 {
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
-  "configurations": [
-
-    {
-      "type": "electron",
-      "request": "launch",
-      "name": "Launch example",
-      "cwd": "${workspaceFolder}",
-      "appDir": "C:/Development/VSCodeProjects/CollabProjects/ffxiv-teamcraft/node_modules/electron-find/example2/main.js",
-      "sourceMaps": true,
-      "breakOnLoad": true
-    },
-    {
-      "name": "Debug Main Process",
-      "type": "node",
-      "request": "launch",
-      "cwd": "${workspaceFolder}",
-      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
-      "windows": {
-        "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
-      },
-      "args" : ["."],
-      "outputCapture": "std"
-    }
-  ]
+  "configurations": [{
+    "name": "Launch Edge",
+    "type": "edge",
+    "request": "launch",
+    "version": "beta",
+    "url": "http://localhost:4200",
+    "webRoot": "${workspaceFolder}/apps/client"
+  }]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,18 +1,13 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "type": "npm",
-            "script": "build:electron-prod",
-            "group": "build",
-            "problemMatcher": []
-        },
-        {
-            "type": "npm",
-            "script": "build:electron-dev",
-            "group": "build",
-            "problemMatcher": []
-        }
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [{
+    "label": "npm start",
+    "type": "npm",
+    "script": "start",
+    "problemMatcher": [
+      "$tsc"
     ]
+  }]
 }
-

--- a/apps/client/src/app/pages/inventory-optimizer/optimizations/consolidate-stacks.ts
+++ b/apps/client/src/app/pages/inventory-optimizer/optimizations/consolidate-stacks.ts
@@ -52,8 +52,8 @@ export class ConsolidateStacks extends InventoryOptimizer {
         return i.itemId === item.itemId
           // If we have no expansion selected to filter on, treat *all* items as "in expansion"
           && (expansion === null || this.itemInExpansion(item.itemId, +expansion))
-          && item.hq === false
-          && i.hq === true
+          && item.hq === true
+          && i.hq === false
           && i.spiritBond === 0
           && !InventoryOptimizer.inSameSlot(i, item)
           && item.quantity + i.quantity < this.lazyData.data.stackSizes[i.itemId]


### PR DESCRIPTION
It was incorrectly identifying the NQ stack as the HQ stack. The
condition is reversed so that the HQ item is properly suggested.

Also reverted changes to files under `.vscode` to an earlier revision because recent changes were unintentional.