### PR TITLE
fix: Disable HQ setting works more thoroughly

### DIFF
--- a/apps/client/src/app/modules/list/+state/lists.facade.ts
+++ b/apps/client/src/app/modules/list/+state/lists.facade.ts
@@ -226,9 +226,7 @@ export class ListsFacade {
     }).afterClose.pipe(
       filter(res => res && res.name !== undefined),
       map(res => {
-        const list = new List();
-        list.everyone = this.settings.defaultPermissionLevel;
-        list.disableHQSuggestions = this.settings.disableHQSuggestions;
+        const list = new List(this.settings);
         list.name = res.name;
         list.ephemeral = res.ephemeral;
         list.offline = res.offline;
@@ -238,8 +236,7 @@ export class ListsFacade {
   }
 
   newEphemeralList(itemName: string): List {
-    const list = new List();
-    list.everyone = this.settings.defaultPermissionLevel;
+    const list = new List(this.settings);
     list.ephemeral = true;
     list.name = itemName;
     return list;

--- a/apps/client/src/app/modules/list/model/list.ts
+++ b/apps/client/src/app/modules/list/model/list.ts
@@ -20,6 +20,7 @@ import { ListManagerService } from '../list-manager.service';
 import { ListColor } from './list-color';
 import * as firebase from 'firebase/app';
 import { DataType } from '../data/data-type';
+import { SettingsService } from '../../settings/settings.service';
 
 declare const gtag: Function;
 
@@ -65,10 +66,15 @@ export class List extends DataWithPermissions {
 
   archived = false;
 
-  constructor() {
+  constructor(settings? : SettingsService) {
     super();
     if (!this.createdAt) {
       this.createdAt = firebase.firestore.Timestamp.fromDate(new Date());
+    }
+
+    if (settings) {
+      this.everyone = settings.defaultPermissionLevel;
+      this.disableHQSuggestions = settings.disableHQSuggestions;
     }
   }
 
@@ -84,6 +90,8 @@ export class List extends DataWithPermissions {
 
   public clone(internal = false): List {
     const clone = new List();
+    clone.everyone = this.everyone;
+    clone.disableHQSuggestions = this.disableHQSuggestions;
     clone.name = this.name;
     clone.version = this.version || '1.0.0';
     clone.tags = this.tags;


### PR DESCRIPTION
There are some edge cases in which this setting would not apply:

1. Creating a list from search results
2. Cloning another list

Now the setting for disabling HQ suggestions in lists works more
thoroughly.

Note that as part of this change, the "everyone" list property is also
more consistently handled.