### PR TITLE
Feat(ux): levequest page "level range" label

### DIFF
--- a/apps/client/src/app/pages/levequests/levequests/levequests.component.html
+++ b/apps/client/src/app/pages/levequests/levequests/levequests.component.html
@@ -28,9 +28,10 @@
     </nz-input-group>
   </div>
 
-  <div [nzMd]="{ span: 5, offset: 1, order: 3 }" [nzXXl]="{ span: 3 }" [nzXs]="{ span: 13, offset: 1, order: 2 }"
+  <div [nzMd]="{ span: 7, offset: 1, order: 3 }" [nzXXl]="{ span: 5 }" [nzXs]="{ span: 13, offset: 1, order: 2 }"
        nz-col>
     <nz-input-group class="levels" nzCompact>
+      <div class="levels range">{{'LEVEQUESTS.Level_range' | translate}}</div>
       <nz-input-number (ngModelChange)="setLevel(levelMin$, $event)" [ngModel]="levelMin$.value" [nzMax]="80"
                        [nzMin]="1"
                        [nzPrecision]="0"></nz-input-number>

--- a/apps/client/src/app/pages/levequests/levequests/levequests.component.less
+++ b/apps/client/src/app/pages/levequests/levequests/levequests.component.less
@@ -34,6 +34,14 @@
 
   .levels {
     width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+
+    .range {
+      white-space: nowrap;
+      padding-right: 5px;
+    }
 
     .ant-input-number {
       width: 40%;

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -1023,6 +1023,7 @@
   "LEVEQUESTS": {
     "Title": "Levequests",
     "Levequest_name": "Levequest name",
+    "Level_range": "Level range",
     "No_results": "No levequests found",
     "Add_to_list": "Add this levequest's items to a list",
     "Quantity": "Quantity",


### PR DESCRIPTION
Adds a "level range" label to the levequests page for clarity.
https://imgur.com/a/bbEWJWW

I touched a lot of html and css that I'm not too familiar with, please kick it back if I need to do things differently, or if this is unnecessary.