### PR TITLE
feat(optimizers): Allowing hiding optimizers

### DIFF
--- a/apps/client/src/app/pages/inventory-optimizer/inventory-optimization.ts
+++ b/apps/client/src/app/pages/inventory-optimizer/inventory-optimization.ts
@@ -14,4 +14,5 @@ export interface InventoryOptimization {
     }[]
   }[]
   totalLength?: number;
+  hidden?: boolean;
 }

--- a/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.html
+++ b/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.html
@@ -1,6 +1,8 @@
 <div fxLayout="row" fxLayoutAlign="space-between center">
   <h2>{{'INVENTORY_OPTIMIZER.Title' | translate}}</h2>
   <div fxLayout="row" fxLayoutGap="5px">
+    <nz-switch [(ngModel)]="showHidden" (ngModelChange)="reloader$.next(null)"></nz-switch>
+    <div class="switch-label">{{'INVENTORY_OPTIMIZER.Show_hidden' | translate}}</div>
     <nz-switch [(ngModel)]="showIgnored" (ngModelChange)="reloader$.next(null)"></nz-switch>
     <div>{{'INVENTORY_OPTIMIZER.Show_ignored' | translate}}</div>
   </div>
@@ -11,9 +13,11 @@
     {{'INVENTORY_OPTIMIZER.No_optimizations' | translate}}
   </app-fullpage-message>
   <nz-spin [nzSpinning]="loading">
-    <div fxLayout="column" fxLayoutGap="10px">
+    <div fxLayout="column">
       <nz-collapse *ngFor="let optimization of optimizations; trackBy: trackByTip">
-        <nz-collapse-panel [nzHeader]="header" [nzExtra]="extraTpl">
+        <nz-collapse-panel 
+          *ngIf="showHidden || !optimization.hidden"
+          [nzHeader]="header" [nzExtra]="extraTpl">
           <ng-template #header>
             {{'INVENTORY_OPTIMIZER.' + optimization.type + '.Title' | translate}} ({{optimization.totalLength}})
           </ng-template>
@@ -61,6 +65,23 @@
                   {{'INVENTORY_OPTIMIZER.UNWANTED_MATERIALS.Recipe_ilvl' | translate}}
                 </ng-template>
               </ng-container>
+              <div class="optimizer-hide-button" fxFlex="0">
+                <button nz-button
+                        *ngIf="!optimization.hidden; else removeHidden"
+                        (click)="$event.stopPropagation();setHideOptimizer(optimization.type, true)"
+                        nzShape="circle" nz-tooltip [nzTitle]="'INVENTORY_OPTIMIZER.Hide_optimizer' | translate"
+                        nzType="danger">
+                  <i nz-icon nzType="eye-invisible"></i>
+                </button>
+                <ng-template #removeHidden>
+                  <button nz-button
+                          (click)="$event.stopPropagation();setHideOptimizer(optimization.type, false)"
+                          nzShape="circle" nz-tooltip [nzTitle]="'INVENTORY_OPTIMIZER.Unhide_optimizer' | translate"
+                          nzType="primary">
+                    <i nz-icon nzType="eye"></i>
+                  </button>
+                </ng-template>
+              </div>
             </ng-container>
           </ng-template>
           <nz-collapse>

--- a/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.less
+++ b/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.less
@@ -1,8 +1,25 @@
 :host ::ng-deep .ant-collapse-header {
-  padding: 12px 12px 12px 40px !important;
+  padding: 12px 24px 12px 40px !important;
+}
+
+:host ::ng-deep .ant-collapse-item {
+  margin-bottom: 10px;  
+}
+
+:host ::ng-deep .ant-collapse {
+  border: 0px;
 }
 
 nz-select {
   margin-right: 8px;
   width: 200px;
+}
+
+.optimizer-hide-button {
+  margin-left: 6px;
+  margin-top: -4px;
+}
+
+.switch-label {
+  padding-right: 24px;
 }

--- a/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.ts
+++ b/apps/client/src/app/pages/inventory-optimizer/inventory-optimizer/inventory-optimizer.component.ts
@@ -94,6 +94,9 @@ export class InventoryOptimizerComponent {
               }
               return entry;
             });
+            opt.hidden = this.hiddenArray.some(hidden => {
+              return hidden.optimizerId === opt.type;
+            });
             opt.totalLength = uniq(total).length;
             return opt;
           });
@@ -104,7 +107,13 @@ export class InventoryOptimizerComponent {
 
   public ignoreArray: { id: string, itemId: number, containerName?: string }[] = JSON.parse(localStorage.getItem(`optimizations:ignored`) || '[]');
 
+  //hiddenArray tracks hidden optimizers
+  public hiddenArray: { optimizerId: string }[] = JSON.parse(localStorage.getItem('optimizations:hidden') || '[]');
+
   public showIgnored = false;
+
+  //for showing hidden optimizers
+  public showHidden = false;
 
   public loading = false;
 
@@ -168,6 +177,25 @@ export class InventoryOptimizerComponent {
 
   nameCopied(key: string, args?: any): void {
     this.message.success(this.translate.instant(key, args));
+  }
+
+  public setHideOptimizer(optimizer: string, hidden: boolean): void {
+    if (hidden) {
+      this.hiddenArray = [
+        ...this.hiddenArray,
+        {
+          optimizerId: optimizer
+        }
+      ];
+    } else {
+      this.hiddenArray = this.hiddenArray.filter(o => o.optimizerId !== optimizer);
+    }
+    this.setHiddenArray(this.hiddenArray);
+    this.reloader$.next();
+  }
+
+  private setHiddenArray(array: {optimizerId: string}[]): void {
+    localStorage.setItem('optimizations:hidden', JSON.stringify(array));
   }
 
   public setIgnoreItemOptimization(itemId: number, optimization: string, ignore: boolean): void {

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -1726,8 +1726,11 @@
     "Ignore_item": "Ignore this tip for this item",
     "Remove_ignore_item": "Don't ignore this tip for this item anymore",
     "Ignore_container": "Ignore this tip for this container",
+    "Hide_optimizer": "Hide this optimizer",
+    "Unhide_optimizer": "Don't hide this optimizer anymore",
     "Remove_ignore_container": "Don't ignore this tip for this container anymore",
     "Show_ignored": "Show ignored items",
+    "Show_hidden": "Show hidden optimizers",
     "No_optimizations": "No optimizations available",
     "CAN_BE_BOUGHT": {
       "Title": "Items that can be bought with gil",


### PR DESCRIPTION
Adds a button on each optimizer to hide it. Also adds a switch to the top of the optimizers page to show hidden optimizers, similar to the switch for showing ignored items/containers.
EDIT: Resolves #1432 