### PR TITLE
Share consumables with crafting rotation URLs

### DIFF
--- a/apps/client/src/app/pages/simulator/abstract-simulation-page.ts
+++ b/apps/client/src/app/pages/simulator/abstract-simulation-page.ts
@@ -3,12 +3,23 @@ import { filter, map } from 'rxjs/operators';
 import { ActivatedRoute } from '@angular/router';
 import { SeoPageComponent } from '../../core/seo/seo-page-component';
 import { SeoService } from '../../core/seo/seo.service';
+import { Consumable } from './model/consumable';
+import { RouteConsumables } from './model/route-consumables';
 
 export abstract class AbstractSimulationPage extends SeoPageComponent {
-  stats$: Observable<{ craftsmanship: number; control: number; cp: number; spec: boolean; level: number }>;
+  stats$: Observable<{
+    craftsmanship: number,
+    control: number,
+    cp: number,
+    spec: boolean,
+    level: number,
+  }>;
+
+  consumables$: Observable<RouteConsumables>;
 
   constructor(protected route: ActivatedRoute, protected seo: SeoService) {
     super(seo);
+
     this.stats$ = this.route.queryParamMap.pipe(
       map(query => {
         return query.get('stats');
@@ -25,5 +36,27 @@ export abstract class AbstractSimulationPage extends SeoPageComponent {
         };
       })
     );
+
+    const consumables = new RouteConsumables;
+    const params = route.snapshot.queryParamMap;
+
+    const food = params.get('food');
+    if (food) {
+      const split = food.split(',');
+      consumables.food = {id: +split[0], hq: split[1] === '1'};
+    }
+
+    const med = params.get('med');
+    if (med) {
+      const split = med.split(',');
+      consumables.medicine = {id: +split[0], hq: split[1] === '1'};
+    }
+
+    const fca = params.get('fca');
+    if (fca) {
+      consumables.freeCompanyActions = fca.split(',').map((n: String) => +n) as [number, number];
+    }
+
+    this.consumables$ = new Observable(observer => observer.next(consumables));
   }
 }

--- a/apps/client/src/app/pages/simulator/abstract-simulation-page.ts
+++ b/apps/client/src/app/pages/simulator/abstract-simulation-page.ts
@@ -1,0 +1,29 @@
+import { Observable } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
+import { ActivatedRoute } from '@angular/router';
+import { SeoPageComponent } from '../../core/seo/seo-page-component';
+import { SeoService } from '../../core/seo/seo.service';
+
+export abstract class AbstractSimulationPage extends SeoPageComponent {
+  stats$: Observable<{ craftsmanship: number; control: number; cp: number; spec: boolean; level: number }>;
+
+  constructor(protected route: ActivatedRoute, protected seo: SeoService) {
+    super(seo);
+    this.stats$ = this.route.queryParamMap.pipe(
+      map(query => {
+        return query.get('stats');
+      }),
+      filter(stats => stats !== null),
+      map(statsStr => {
+        const split = statsStr.split('/');
+        return {
+          craftsmanship: +split[0],
+          control: +split[1],
+          cp: +split[2],
+          level: +split[3],
+          spec: +split[3] === 1
+        };
+      })
+    );
+  }
+}

--- a/apps/client/src/app/pages/simulator/components/custom-simulator-page/custom-simulator-page.component.ts
+++ b/apps/client/src/app/pages/simulator/components/custom-simulator-page/custom-simulator-page.component.ts
@@ -5,27 +5,25 @@ import { combineLatest, merge, Observable } from 'rxjs';
 import { filter, map, startWith, tap } from 'rxjs/operators';
 import { ActivatedRoute } from '@angular/router';
 import { RotationsFacade } from '../../../../modules/rotations/+state/rotations.facade';
-import { SeoPageComponent } from '../../../../core/seo/seo-page-component';
 import { SeoService } from '../../../../core/seo/seo.service';
 import { SeoMetaConfig } from '../../../../core/seo/seo-meta-config';
 import { CraftingRotation } from '../../../../model/other/crafting-rotation';
+import { AbstractSimulationPage } from '../../abstract-simulation-page';
 
 @Component({
   selector: 'app-custom-simulator-page',
   templateUrl: './custom-simulator-page.component.html',
   styleUrls: ['./custom-simulator-page.component.less']
 })
-export class CustomSimulatorPageComponent extends SeoPageComponent {
+export class CustomSimulatorPageComponent extends AbstractSimulationPage {
 
   public recipeForm: FormGroup;
 
   public recipe$: Observable<Partial<Craft>>;
 
-  stats$: Observable<{ craftsmanship: number, control: number, cp: number, spec: boolean, level: number }>;
-
-  constructor(private fb: FormBuilder, private route: ActivatedRoute,
+  constructor(private fb: FormBuilder, protected route: ActivatedRoute,
               private rotationsFacade: RotationsFacade, protected seo: SeoService) {
-    super(seo);
+    super(route, seo);
     this.route.paramMap.pipe(
       map(params => params.get('rotationId'))
     ).subscribe(id => {
@@ -89,23 +87,6 @@ export class CustomSimulatorPageComponent extends SeoPageComponent {
           suggCraft: recipe.suggestedCraftsmanship,
           suggCtrl: recipe.suggestedControl
         }, { emitEvent: false });
-      })
-    );
-
-    this.stats$ = this.route.queryParamMap.pipe(
-      map(query => {
-        return query.get('stats');
-      }),
-      filter(stats => stats !== null),
-      map(statsStr => {
-        const split = statsStr.split('/');
-        return {
-          craftsmanship: +split[0],
-          control: +split[1],
-          cp: +split[2],
-          level: +split[3],
-          spec: +split[3] === 1
-        };
       })
     );
   }

--- a/apps/client/src/app/pages/simulator/components/simulation-share-popup/simulation-share-popup.component.ts
+++ b/apps/client/src/app/pages/simulator/components/simulation-share-popup/simulation-share-popup.component.ts
@@ -1,9 +1,11 @@
 import { Component } from '@angular/core';
-import { Simulation } from '@ffxiv-teamcraft/simulator';
+import { CrafterStats } from '@ffxiv-teamcraft/simulator';
 import { CraftingRotation } from 'apps/client/src/app/model/other/crafting-rotation';
 import { LinkToolsService } from '../../../../core/tools/link-tools.service';
 import { NzMessageService, NzModalRef } from 'ng-zorro-antd';
 import { TranslateService } from '@ngx-translate/core';
+import { Consumable } from '../../model/consumable';
+import { FreeCompanyAction } from '../../model/free-company-action';
 
 @Component({
   selector: 'app-simulation-share-popup',
@@ -12,14 +14,25 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class SimulationSharePopupComponent {
 
-  simulation: Simulation;
-
   rotation: CraftingRotation;
-
+  stats: CrafterStats;
   includeStats: boolean;
+  food: Consumable;
+  medicine: Consumable;
+  freeCompanyActions: FreeCompanyAction[];
 
   constructor(private linkTools: LinkToolsService, private message: NzMessageService,
               private translate: TranslateService, private modalRef: NzModalRef) {
+  }
+
+  getStatsParam(): string[] {
+    return [
+      String(this.stats.craftsmanship),
+      String(this.stats._control),
+      String(this.stats.cp),
+      String(this.stats.level),
+      this.stats.specialist ? '1' : '0',
+    ];
   }
 
   getLink(): string {
@@ -29,14 +42,29 @@ export class SimulationSharePopupComponent {
     } else {
       baseLink = this.linkTools.getLink(`/simulator/${this.rotation.defaultItemId}/${this.rotation.defaultRecipeId}/${this.rotation.$key}`);
     }
+
     if (this.includeStats) {
-      return `${baseLink}?stats=${
-        this.simulation.crafterStats.craftsmanship}/${
-        this.simulation.crafterStats._control}/${
-        this.simulation.crafterStats.cp}/${
-        this.simulation.crafterStats.level}/${
-        this.simulation.crafterStats.specialist ? '1' : '0'}`;
+      const makePair = (item: Consumable) => `${item.itemId},${item.hq ? 1 : 0}`;
+
+      const params = [
+        `stats=${this.getStatsParam().join('/')}`,
+      ];
+
+      if (this.food) {
+        params.push(`food=${makePair(this.food)}`);
+      }
+
+      if (this.medicine) {
+        params.push(`med=${makePair(this.medicine)}`);
+      }
+
+      if (this.freeCompanyActions && this.freeCompanyActions.length > 0) {
+        params.push(`fca=${this.freeCompanyActions.map(fca => fca.actionId).join(',')}`);
+      }
+
+      baseLink += '?' + params.join('&');
     }
+
     return baseLink;
   }
 

--- a/apps/client/src/app/pages/simulator/components/simulator-page/simulator-page.component.html
+++ b/apps/client/src/app/pages/simulator/components/simulator-page/simulator-page.component.html
@@ -1,5 +1,10 @@
-<app-simulator *ngIf="recipe$ | async as recipe; else loading" [item]="item$ | async" [recipe]="recipe"
-               [thresholds]="thresholds$ | async" [routeStats]="stats$ | async"></app-simulator>
+<app-simulator *ngIf="recipe$ | async as recipe; else loading"
+  [item]="item$ | async"
+  [recipe]="recipe"
+  [thresholds]="thresholds$ | async"
+  [routeStats]="stats$ | async"
+  [routeConsumables]="consumables$ | async">
+</app-simulator>
 <ng-template #loading>
   <app-page-loader></app-page-loader>
 </ng-template>

--- a/apps/client/src/app/pages/simulator/components/simulator-page/simulator-page.component.ts
+++ b/apps/client/src/app/pages/simulator/components/simulator-page/simulator-page.component.ts
@@ -11,26 +11,25 @@ import { SeoMetaConfig } from '../../../../core/seo/seo-meta-config';
 import { hwdSupplies } from '../../../../core/data/sources/hwd-supplies';
 import { LazyDataService } from '../../../../core/data/lazy-data.service';
 import { Craft } from '@ffxiv-teamcraft/simulator';
+import { AbstractSimulationPage } from '../../abstract-simulation-page';
 
 @Component({
   selector: 'app-simulator-page',
   templateUrl: './simulator-page.component.html',
   styleUrls: ['./simulator-page.component.less']
 })
-export class SimulatorPageComponent extends SeoPageComponent {
+export class SimulatorPageComponent extends AbstractSimulationPage {
 
   recipe$: Observable<Craft>;
 
   item$: Observable<Item>;
 
-  stats$: Observable<{ craftsmanship: number, control: number, cp: number, spec: boolean, level: number }>;
-
   thresholds$: Observable<number[]>;
 
-  constructor(private route: ActivatedRoute, private dataService: DataService,
+  constructor(protected route: ActivatedRoute, private dataService: DataService,
               private rotationsFacade: RotationsFacade, private router: Router,
               protected seo: SeoService, private lazyData: LazyDataService) {
-    super(seo);
+    super(route, seo);
     this.route.paramMap.pipe(
       map(params => params.get('rotationId'))
     ).subscribe(id => {
@@ -49,23 +48,6 @@ export class SimulatorPageComponent extends SeoPageComponent {
       }),
       map(itemData => itemData.item),
       shareReplay(1)
-    );
-
-    this.stats$ = this.route.queryParamMap.pipe(
-      map(query => {
-        return query.get('stats');
-      }),
-      filter(stats => stats !== null),
-      map(statsStr => {
-        const split = statsStr.split('/');
-        return {
-          craftsmanship: +split[0],
-          control: +split[1],
-          cp: +split[2],
-          level: +split[3],
-          spec: +split[3] === 1
-        };
-      })
     );
 
     this.thresholds$ = this.item$.pipe(

--- a/apps/client/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/apps/client/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -65,14 +65,16 @@
               nzType="primary">
         <i nz-icon nzType="ordered-list"></i>
       </button>
-      <button (click)="openSharePopup(rotation)"
-              *ngIf="rotation.$key"
-              [nzShape]="'circle'"
-              [nzTitle]="'SIMULATOR.Share_button_tooltip' | translate"
-              [nzType]="'primary'"
-              nz-button nz-tooltip>
-        <i nz-icon nzType="share-alt"></i>
-      </button>
+      <ng-container *ngIf="crafterStats$ | async as stats">
+        <button (click)="openSharePopup(rotation, stats)"
+                *ngIf="rotation.$key"
+                [nzShape]="'circle'"
+                [nzTitle]="'SIMULATOR.Share_button_tooltip' | translate"
+                [nzType]="'primary'"
+                nz-button nz-tooltip>
+          <i nz-icon nzType="share-alt"></i>
+        </button>
+      </ng-container>
       <button (click)="openRotationSolver()" [nzShape]="'circle'"
               [nzTitle]="'SIMULATOR.Rotation_solver' | translate"
               [nzType]="'primary'"

--- a/apps/client/src/app/pages/simulator/model/route-consumables.ts
+++ b/apps/client/src/app/pages/simulator/model/route-consumables.ts
@@ -1,0 +1,7 @@
+import { ConsumableRow } from '../../../model/user/consumable-row';
+
+export class RouteConsumables {
+  food: ConsumableRow;
+  medicine: ConsumableRow;
+  freeCompanyActions: [number, number];
+}

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -800,7 +800,7 @@
   },
   "SIMULATOR": {
     "Title": "Crafting simulator",
-    "Include_stats": "Include stats",
+    "Include_stats": "Include stats and consumables",
     "Fixed_notification_number": "Fixed notification",
     "Starting_echo_number": "Notification #",
     "Break_on_reclaim": "Split macros on Reclaim point-of-no-return",


### PR DESCRIPTION
feat: Share consumables with rotations

Now when including stats with crafting rotation links, the following
consumables are included:

* Selected Food
* Selected Medicine
* Up to two selected free company actions

This allows others that open your rotations via the link to see your
selected consumables. Previously the consumable stats were part of the
stats parameters which allowed others to add another food on top of it,
for example, effectively invalidating the simulation.
