### PR TITLE
Feat/inventory expac filter

### DIFF
--- a/apps/client/src/app/pages/inventory/inventory/inventory.component.html
+++ b/apps/client/src/app/pages/inventory/inventory/inventory.component.html
@@ -11,6 +11,7 @@
     <button nz-button nzType="danger" nz-popconfirm [nzTitle]="'Confirmation' | translate"
             (nzOnConfirm)="deleteInventories()">{{'INVENTORY.Clean_all' | translate}}</button>
   </div>
+  <div class="search-tip" fxLayout="row" fxLayoutAlign="left center">{{'INVENTORY.Search_tip' | translate}}</div>
   <div nz-row>
     <div *ngFor="let inventory of display; trackBy: trackByInventory" class="bag-container" nz-col nzMd="12" nzSm="24">
       <nz-spin [nzSpinning]="computingPrices[inventory.containerName]">

--- a/apps/client/src/app/pages/inventory/inventory/inventory.component.less
+++ b/apps/client/src/app/pages/inventory/inventory/inventory.component.less
@@ -15,3 +15,9 @@
 .bag-item {
   padding: 8px !important;
 }
+
+.search-tip {
+  font-style: italic;
+  font-size: 11px;
+  padding-left: 14px;
+}

--- a/apps/client/src/app/pages/inventory/inventory/inventory.component.ts
+++ b/apps/client/src/app/pages/inventory/inventory/inventory.component.ts
@@ -106,7 +106,7 @@ export class InventoryComponent {
               const expacRegexString: string = allExpansions.concat(Object.keys(expacAbbreviations)).join('|');
               const expacRegex: RegExp = new RegExp(`(expac|expansion):(${expacRegexString})`, 'i');
 
-              const expacMatches: string[] = expacRegex.exec(search);
+              const expacMatches: string[] = expacRegex.exec(processedSearch);
               if (expacMatches && expacMatches[2]) {
                 processedSearch = processedSearch.replace(expacRegex, '');
                 //Find data matching either a full expansion's name, or an abbreviation we defined above

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -1715,6 +1715,7 @@
     "Reset_inventory": "Reset this inventory",
     "Clean_all": "Reset all your inventories",
     "Search_for_an_item": "Search for an item",
+    "Search_tip": "You can filter by expansion, try searching with expansion:Shadowbringers or expac:ShB",
     "In_x_containers": "In {{amount}} containers",
     "BAG": {
       "SaddleBag": "Chocobo Saddlebag",


### PR DESCRIPTION
Resolves #1449 
Can use 'expansion:' or 'expac:' and then either full names of expansions, or manually added (in the code) abbreviations. It should automatically be able to still use the full name of any future expansions when they come out, but abbreviations will need to be added manually :(
Examples:
expansion:Heavensward
expac:ShB
expac:A Realm Reborn

None of it is case sensitive.