### PR TITLE
Implement scrollbar to prevent drop-down items being inaccessible

### DIFF
--- a/apps/client/src/app/pages/gearset/materias-popup/materias-popup.component.html
+++ b/apps/client/src/app/pages/gearset/materias-popup/materias-popup.component.html
@@ -50,7 +50,7 @@
         <ul nz-menu>
           <li nz-menu-item (click)="resetMaterias(i)">{{'GEARSETS.No_materia' | translate}}</li>
           <li nz-submenu *ngFor="let row of materiaMenu" [nzTitle]="row.baseParamId | baseParamName | i18n">
-            <ul>
+            <ul style="width: 300px; height: 200px; overflow: auto">
               <li nz-menu-item
                   (click)="setMateria(i, materia)"
                   [nzDisabled]="getMeldingChances(materia, i) === 0"


### PR DESCRIPTION
Fix for #1517 

Implemented a scrollbar to prevent drop-down items from being soft-locked by window/screen ratio.