### PR TITLE
fix(currency-spending): filter out shop listings with no npc

### DIFF
--- a/apps/client/src/app/pages/currency-spending/currency-spending/currency-spending.component.ts
+++ b/apps/client/src/app/pages/currency-spending/currency-spending/currency-spending.component.ts
@@ -86,7 +86,7 @@ export class CurrencySpendingComponent extends TeamcraftComponent {
         this.loading = true;
         return this.dataService.getItem(currency).pipe(
           map((item: ItemData) => {
-            return [].concat.apply([], item.item.tradeCurrency.map(entry => {
+            return [].concat.apply([], item.item.tradeCurrency.filter(entry => entry.npcs.length > 0).map(entry => {
               return entry.listings.map(listing => {
                 const currencyEntry = listing.currency.find(c => +c.id === currency);
                 return {


### PR DESCRIPTION
Garland contains old shop listings which no longer exist in game.
Many items have simply been moved under a different shop listing,
resulting in the currency spending page showing duplicate items.

You can see the incorrect behavior by looking at `Yellow Crafters' Scrip` currency, as shown below:
![image](https://user-images.githubusercontent.com/63636/86622534-05b17a80-bf8e-11ea-8647-91b781265274.png)