### PR TITLE
fix(desktop): fix "cannot acquire lock" error

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -148,6 +148,7 @@ if (options.noHA) {
  * Autoupdater
  */
 
+let autoUpdaterRunning = false
 autoUpdater.on('checking-for-update', () => {
   log.log('Checking for update');
   win && win.webContents.send('checking-for-update', true);
@@ -160,11 +161,19 @@ autoUpdater.on('update-available', () => {
 
 autoUpdater.on('update-not-available', () => {
   log.log('No update found');
+  autoUpdaterRunning = false;
+  win && win.webContents.send('update-available', false);
+});
+
+autoUpdater.on('error', (err) => {
+  log.log('Updater Error', err);
+  autoUpdaterRunning = false;
   win && win.webContents.send('update-available', false);
 });
 
 autoUpdater.on('update-downloaded', () => {
   log.log('Update downloaded');
+  autoUpdaterRunning = false;
   dialog.showMessageBox({
     type: 'info',
     title: 'FFXIV Teamcraft - Update available',
@@ -180,7 +189,12 @@ autoUpdater.on('update-downloaded', () => {
 
 
 ipcMain.on('update:check', () => {
+  if (autoUpdaterRunning) {
+    return;
+  }
+
   log.log('Run update setup');
+  autoUpdaterRunning = true;
   autoUpdater.checkForUpdates();
 });
 


### PR DESCRIPTION
**Cause**:
![image](https://user-images.githubusercontent.com/2197479/88180870-9790d700-cc60-11ea-8494-90b525aab7c5.png)

`newVersionAvailable` is triggered **twice**, so as `updateDesktopApp`, `ipc.send('update:check')` and `autoUpdater.checkForUpdates()`

![image](https://user-images.githubusercontent.com/2197479/88180746-6d3f1980-cc60-11ea-8395-aef7ee3efa21.png)

SquirrelUpdater will try to `touch` a lock file on startup. So when it's called the second time, lock is already opened by the first one and the exception is thrown.
![image](https://user-images.githubusercontent.com/2197479/88181064-e474ad80-cc60-11ea-8e7f-f351be48829a.png)

Adding a lock to autoUpdater should prevent the second call and fix this error.