### PR TITLE
chore(desynth): delete invalid filter

### DIFF
--- a/apps/client/src/app/pages/desynth/desynth/desynth.component.ts
+++ b/apps/client/src/app/pages/desynth/desynth/desynth.component.ts
@@ -77,11 +77,6 @@ export class DesynthComponent {
           indexes: [SearchIndex.ITEM],
           filters: [
             {
-              column: 'Salvage.ID',
-              operator: '>=',
-              value: 0
-            },
-            {
               column: 'LevelItem',
               operator: '>=',
               value: Math.max(dlvl - 10, 0)


### PR DESCRIPTION
I don't know how to distinguish isDesynthesizable.

![image](https://i.imgur.com/OBlUfx5.png)

Salvage has deleted, but that column still seems to be valid.

It's just a conjecture, so it's not clear.