### PR TITLE
Feat/Add exclusion filter

### DIFF
--- a/apps/client/src/app/pages/community-lists/community-lists/community-lists.component.html
+++ b/apps/client/src/app/pages/community-lists/community-lists/community-lists.component.html
@@ -16,12 +16,12 @@
   </div>
   <div class="filter-input" fxLayout="row" fxLayoutGap="5px">
     <nz-select (ngModelChange)="excludeFilter$.next($event)" [ngModel]="excludeFilter$ | async"
-               [nzPlaceHolder]="'COMMUNITY_LISTS.Tags_filter_placeholder' | translate"
+               [nzPlaceHolder]="'COMMUNITY_LISTS.Exclude_filter_placeholder' | translate"
                fxFlex="1 1 auto"
                nzMode="multiple">
       <nz-option *ngFor="let tag of tags" [nzLabel]="tag.label | translate" [nzValue]="tag.value"></nz-option>
     </nz-select>
-    <button (click)="excludeFilter$.next([])" [nzTitle]="'COMMUNITY_LISTS.Tags_filter_reset' | translate" nz-button
+    <button (click)="excludeFilter$.next([])" [nzTitle]="'COMMUNITY_LISTS.Exclude_filter_reset' | translate" nz-button
             nz-tooltip>
       <i nz-icon nzType="reload"></i>
     </button>

--- a/apps/client/src/app/pages/community-lists/community-lists/community-lists.component.html
+++ b/apps/client/src/app/pages/community-lists/community-lists/community-lists.component.html
@@ -14,6 +14,18 @@
       <i nz-icon nzType="reload"></i>
     </button>
   </div>
+  <div class="filter-input" fxLayout="row" fxLayoutGap="5px">
+    <nz-select (ngModelChange)="excludeFilter$.next($event)" [ngModel]="excludeFilter$ | async"
+               [nzPlaceHolder]="'COMMUNITY_LISTS.Tags_filter_placeholder' | translate"
+               fxFlex="1 1 auto"
+               nzMode="multiple">
+      <nz-option *ngFor="let tag of tags" [nzLabel]="tag.label | translate" [nzValue]="tag.value"></nz-option>
+    </nz-select>
+    <button (click)="excludeFilter$.next([])" [nzTitle]="'COMMUNITY_LISTS.Tags_filter_reset' | translate" nz-button
+            nz-tooltip>
+      <i nz-icon nzType="reload"></i>
+    </button>
+  </div>
   <app-page-loader [loading]="loading" class="lists-container">
     <div *ngIf="filteredLists$ | async as lists" fxFlex="1 1 auto" fxLayout="column" fxLayoutGap="5px">
       <app-list-panel *ngFor="let list of lists; trackBy: trackByList" [list]="list"

--- a/apps/client/src/app/pages/community-lists/community-lists/community-lists.component.ts
+++ b/apps/client/src/app/pages/community-lists/community-lists/community-lists.component.ts
@@ -78,7 +78,7 @@ export class CommunityListsComponent implements OnDestroy {
       switchMap((filters) => {
         return this.listService.getCommunityLists(filters.tags, filters.name).pipe(
           map(lists => {
-            return lists.filter(list => !list.tags.some(tags => filters.exclude.indexOf(tags) > -1));
+            return lists.filter(list => !list.tags.some(tags => filters.exclude.includes(tags)));
           }),
           tap(lists => {
             this.totalLength = lists.length;

--- a/apps/client/src/app/pages/community-lists/community-lists/community-lists.component.ts
+++ b/apps/client/src/app/pages/community-lists/community-lists/community-lists.component.ts
@@ -16,7 +16,7 @@ export class CommunityListsComponent implements OnDestroy {
 
   public tags: any[];
 
-  private filters$: Observable<{ tags: string[], name: string }>;
+  private filters$: Observable<{ tags: string[], name: string, exclude: string[] }>;
 
   public tagsFilter$: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
 
@@ -77,6 +77,9 @@ export class CommunityListsComponent implements OnDestroy {
       debounceTime(250),
       switchMap((filters) => {
         return this.listService.getCommunityLists(filters.tags, filters.name).pipe(
+          map(lists => {
+            return lists.filter(list => !list.tags.some(tags => filters.exclude.indexOf(tags) > -1));
+          }),
           tap(lists => {
             this.totalLength = lists.length;
           }),

--- a/apps/client/src/app/pages/community-lists/community-lists/community-lists.component.ts
+++ b/apps/client/src/app/pages/community-lists/community-lists/community-lists.component.ts
@@ -20,6 +20,8 @@ export class CommunityListsComponent implements OnDestroy {
 
   public tagsFilter$: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
 
+  public excludeFilter$: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
+
   public nameFilter$: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
   public page$: BehaviorSubject<number> = new BehaviorSubject<number>(1);
@@ -40,22 +42,23 @@ export class CommunityListsComponent implements OnDestroy {
         label: `LIST_TAGS.${key}`
       };
     });
-    this.filters$ = combineLatest([this.nameFilter$, this.tagsFilter$]).pipe(
-      tap(([name, tags]) => {
+    this.filters$ = combineLatest([this.nameFilter$, this.tagsFilter$, this.excludeFilter$]).pipe(
+      tap(([name, tags, exclude]) => {
         this.page$.next(1);
         const queryParams = {};
         if (name !== '') {
           queryParams['name'] = name;
         }
         queryParams['tags'] = tags.join(',');
+        queryParams['exclude'] = exclude.join(',');
         router.navigate([], {
           queryParamsHandling: 'merge',
           queryParams: queryParams,
           relativeTo: route
         });
       }),
-      map(([name, tags]) => {
-        return { name: name, tags: tags };
+      map(([name, tags, exclude]) => {
+        return { name: name, tags: tags, exclude: exclude };
       })
     );
     route.queryParamMap
@@ -64,6 +67,9 @@ export class CommunityListsComponent implements OnDestroy {
         this.nameFilter$.next(query.get('name') || '');
         if (query.get('tags') !== null) {
           this.tagsFilter$.next(query.get('tags').split(',').filter(tag => tag !== ''));
+        }
+        if (query.get('exclude') !== null) {
+          this.excludeFilter$.next(query.get('exclude').split(',').filter(exclude => exclude !== ''));
         }
       });
     this.filteredLists$ = this.filters$.pipe(

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -117,6 +117,8 @@
   "COMMUNITY_LISTS": {
     "Tags_filter_placeholder": "Filter using tags",
     "Tags_filter_reset": "Reset tags filter",
+    "Exclude_filter_placeholder": "Exclude using tags",
+    "Exclude_filter_reset": "Reset exclusion filter",
     "Name_filter_placeholder": "Filter using name",
     "No_lists_matching": "No lists matching your filters"
   },


### PR DESCRIPTION
Resolves #1460

Simple UI, just a copy of the tags filter placed below it. The exclusion filter is included as a query string, similar to the tags filter.

It checks if at least one of the lists' tags is also in the exclude filter, and if it is then it will be filtered out of the displayed lists.

My last attempt at a pull request highlighted a huge error I had in my fork because of not syncing with the upstream correctly, causing it to include over 150 Merge Pull Requests. I'm still a little new to git so I apologize for any weirdness.