### PR TITLE
7.3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="7.3.11"></a>
+## [7.3.11](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/compare/v7.3.10...v7.3.11) (2020-08-26)
+
+
+### Bug Fixes
+
+* **community-rotations:** fixed tags taking too much space in some browsers ([90bd053](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/90bd053))
+* **desktop:** possible fix for shortcut creation, will be effective on next patch ([e49f1c2](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/e49f1c2))
+* **metrics:** fixed retainer gil gains counted twice ([b04450b](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/b04450b))
+* **recipe-finder:** fixed an issue with min lvl filter being readonly ([a437960](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/a437960))
+* **trade:** changed icon priority for Allied Seals ([408d9d0](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/408d9d0))
+
+
+### Features
+
+* **data:** support for 5.3 hotfix price changes ([4eadeb1](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/4eadeb1))
+
+
+
 <a name="7.3.10"></a>
 ## [7.3.10](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/compare/v7.3.9...v7.3.10) (2020-08-25)
 

--- a/apps/client/src/app/core/electron/machina.service.ts
+++ b/apps/client/src/app/core/electron/machina.service.ts
@@ -21,7 +21,6 @@ import { SettingsService } from '../../modules/settings/settings.service';
 import { Region } from '../../modules/settings/region.enum';
 import { environment } from '../../../environments/environment';
 import { LazyDataService } from '../data/lazy-data.service';
-import { InventoryEvent } from '../../model/user/inventory/inventory-event';
 import { InventoryEventType } from '../../model/user/inventory/inventory-event-type';
 
 @Injectable({
@@ -338,7 +337,9 @@ export class MachinaService {
   private getEventType(patch: InventoryPatch): InventoryEventType {
     if (patch.quantity > 0) {
       return InventoryEventType.ADDED;
-    } else {
+    } else if(patch.moved) {
+      return InventoryEventType.MOVED;
+    } else{
       return InventoryEventType.REMOVED;
     }
   }

--- a/apps/client/src/app/model/user/inventory/inventory-event-type.ts
+++ b/apps/client/src/app/model/user/inventory/inventory-event-type.ts
@@ -1,4 +1,5 @@
 export enum InventoryEventType {
   REMOVED,
-  ADDED
+  ADDED,
+  MOVED
 }

--- a/apps/client/src/app/modules/player-metrics/probes/currencies-probe.ts
+++ b/apps/client/src/app/modules/player-metrics/probes/currencies-probe.ts
@@ -7,6 +7,7 @@ import { MachinaService } from '../../../core/electron/machina.service';
 import { ContainerType } from '../../../model/user/inventory/container-type';
 import { IpcService } from '../../../core/electron/ipc.service';
 import { ProbeSource } from '../model/probe-source';
+import { InventoryEventType } from '../../../model/user/inventory/inventory-event-type';
 
 export class CurrenciesProbe extends PlayerMetricProbe {
   constructor(protected ipc: IpcService, private machina: MachinaService) {
@@ -15,7 +16,7 @@ export class CurrenciesProbe extends PlayerMetricProbe {
 
   getReports(): Observable<ProbeReport> {
     return this.machina.inventoryEvents$.pipe(
-      filter(patch => patch.containerId === ContainerType.Currency || patch.containerId === ContainerType.RetainerGil),
+      filter(patch => patch.type !== InventoryEventType.MOVED && (patch.containerId === ContainerType.Currency || patch.containerId === ContainerType.RetainerGil)),
       withLatestFrom(this.source$),
       map(([event, source]) => {
         if (event.amount > 0 && (source === ProbeSource.TELEPORT || source === ProbeSource.MARKETBOARD)) {

--- a/apps/client/src/app/pages/recipe-finder/recipe-finder/recipe-finder.component.html
+++ b/apps/client/src/app/pages/recipe-finder/recipe-finder/recipe-finder.component.html
@@ -70,7 +70,7 @@
         {{'RECIPE_FINDER.Recipe_level' | translate}}:
       </div>
       <nz-input-group class="level-range" nzCompact>
-        <nz-input-number mouseWheel [nzMax]="0" [nzMin]="0" [nzPrecision]="0" [ngModel]="clvlMin$ | async"
+        <nz-input-number mouseWheel [nzMax]="maxLevel" [nzMin]="0" [nzPrecision]="0" [ngModel]="clvlMin$ | async"
                          (ngModelChange)="clvlMin$.next($event)" (mouseWheelDown)="clvlMin$.next(clvlMin$.value - 1)"
                          (mouseWheelUp)="clvlMin$.next(clvlMin$.value + 1)"></nz-input-number>
         <input disabled nz-input placeholder="-" type="text">

--- a/apps/client/src/app/pages/simulator/components/rotation-panel/rotation-panel.component.html
+++ b/apps/client/src/app/pages/simulator/components/rotation-panel/rotation-panel.component.html
@@ -7,7 +7,7 @@
           <div>{{rotation.getName()}}</div>
           <app-user-avatar *ngIf="publicDisplay" [userId]="rotation.authorId" [width]="24"></app-user-avatar>
         </div>
-        <div fxFlex="1 1 auto" fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
+        <div fxFlex="1 1 auto" fxLayout="row wrap" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
           <ng-container *ngIf="rotation.public">
             <nz-tag *ngIf="rotation.public && !publicDisplay" [style.border-color]="'#108ee9'" class="custom-tag">
               {{'SIMULATOR.COMMUNITY_ROTATIONS.Community_rotation' | translate}}

--- a/apps/client/src/app/pipes/pipes/trade-icon.pipe.ts
+++ b/apps/client/src/app/pipes/pipes/trade-icon.pipe.ts
@@ -12,7 +12,7 @@ export class TradeIconPipe implements PipeTransform {
     20: 30, // Storm
     21: 30, // Serpent
     22: 30, // Flame
-    27: 30, // Allied
+    27: 29, // Allied
     10307: 30, // Centurio
     26533: 30, // Sack of nuts (lol)
     // Scripts

--- a/apps/client/src/environments/extracts-hash.ts
+++ b/apps/client/src/environments/extracts-hash.ts
@@ -1,1 +1,1 @@
-export const extractsHash = `75cf4ff633b5fc383b8da398c261095f2d506772`;
+export const extractsHash = `04ca5cb3c1b606a89dd3a26ef8ff9f860c0c621c`;

--- a/apps/client/src/environments/patch-notes.ts
+++ b/apps/client/src/environments/patch-notes.ts
@@ -13,4 +13,4 @@ export const patchNotes = `### Bug Fixes
 * **lists:** pinned list now persists over sessions.
 * **recipe-finder:** added filters to the finder.
 * **simulator:** better indicator for unapplied consumables settings.
-* Add zone name to Gathering Items result card.`;
+* Add zone name to Gathering Items result card.`;

--- a/apps/client/src/environments/patch-notes.ts
+++ b/apps/client/src/environments/patch-notes.ts
@@ -13,4 +13,4 @@ export const patchNotes = `### Bug Fixes
 * **lists:** pinned list now persists over sessions.
 * **recipe-finder:** added filters to the finder.
 * **simulator:** better indicator for unapplied consumables settings.
-* Add zone name to Gathering Items result card.`;
+* Add zone name to Gathering Items result card.`;

--- a/apps/client/src/environments/patch-notes.ts
+++ b/apps/client/src/environments/patch-notes.ts
@@ -1,16 +1,12 @@
 export const patchNotes = `### Bug Fixes
 
-* **metrics:** filtering undefined source out of display.
-* **pricing:** fixed an issue with mb filling sometimes stopping.
+* **community-rotations:** fixed tags taking too much space in some browsers.
+* **desktop:** possible fix for shortcut creation, will be effective on next patch.
+* **metrics:** fixed retainer gil gains counted twice.
+* **recipe-finder:** fixed an issue with min lvl filter being readonly.
+* **trade:** changed icon priority for Allied Seals.
 
 
 ### Features
 
-* **alarms:** you can now share alarm groups.
-* **community-lists:** added tag exclusion filter.
-* **core:** support for 5.3 hotfix update.
-* **gearsets:** added scrip cost to materias table.
-* **lists:** pinned list now persists over sessions.
-* **recipe-finder:** added filters to the finder.
-* **simulator:** better indicator for unapplied consumables settings.
-* Add zone name to Gathering Items result card.`;
+* **data:** support for 5.3 hotfix price changes.`;

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -47,7 +47,6 @@ function handleSquirrelEvent() {
       if (!config.get('setup:noShortcut')) {
         spawnUpdate(['--createShortcut', exeName]);
       }
-      ChildProcess.exec('netsh advfirewall firewall delete rule name="ffxiv teamcraft.exe"');
       Machina.addMachinaFirewallRule();
       break;
     case '--squirrel-updated':
@@ -719,7 +718,7 @@ ipcMain.on('no-shortcut', (event, noShortcut) => {
 });
 
 ipcMain.on('no-shortcut:get', (event) => {
-  event.sender.send('always-on-top:value', config.get('setup:noShortcut') || false);
+  event.sender.send('no-shortcut:value', config.get('setup:noShortcut') || false);
 });
 
 ipcMain.on('always-quit', (event, flag) => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Collaborative crafting made easy",
   "homepage": "https://ffxivteamcraft.com",
   "author": "FFXIV Teamcraft",
-  "version": "7.3.10",
+  "version": "7.3.11",
   "license": "MIT",
   "main": "desktop/main.js",
   "build": {


### PR DESCRIPTION
### Bug Fixes

* **community-rotations:** fixed tags taking too much space in some browsers.
* **desktop:** possible fix for shortcut creation, will be effective on next patch.
* **metrics:** fixed retainer gil gains counted twice.
* **recipe-finder:** fixed an issue with min lvl filter being readonly.
* **trade:** changed icon priority for Allied Seals.


### Features

* **data:** support for 5.3 hotfix price changes.