### PR TITLE
Style/combine latest lint

### DIFF
--- a/apps/client/src/app/modules/custom-alarm-popup/custom-alarm-popup/custom-alarm-popup.component.ts
+++ b/apps/client/src/app/modules/custom-alarm-popup/custom-alarm-popup/custom-alarm-popup.component.ts
@@ -140,7 +140,7 @@ export class CustomAlarmPopupComponent implements OnInit {
       weathersFrom: [this.weathersFrom]
     });
 
-    this.mapWeathers$ = combineLatest(this.form.valueChanges, this.maps$).pipe(
+    this.mapWeathers$ = combineLatest([this.form.valueChanges, this.maps$]).pipe(
       map(([form, maps]) => {
         return maps.find(m => m.ID === form.mapId);
       }),

--- a/apps/client/src/app/modules/custom-items/+state/custom-items.facade.ts
+++ b/apps/client/src/app/modules/custom-items/+state/custom-items.facade.ts
@@ -34,7 +34,7 @@ export class CustomItemsFacade {
     map(folders => folders.sort((a, b) => a.index - b.index))
   );
 
-  customItemsDisplay$: Observable<CustomItemsDisplay> = combineLatest(this.allCustomItems$, this.allCustomItemFolders$).pipe(
+  customItemsDisplay$: Observable<CustomItemsDisplay> = combineLatest([this.allCustomItems$, this.allCustomItemFolders$]).pipe(
     map(([items, folders]) => {
       return {
         otherItems: items.filter(item => item !== undefined && !folders.some(folder => folder.items.some(key => key === item.$key))),

--- a/apps/client/src/app/modules/custom-links/+state/custom-links.facade.ts
+++ b/apps/client/src/app/modules/custom-links/+state/custom-links.facade.ts
@@ -28,7 +28,7 @@ export class CustomLinksFacade {
     select(customLinksQuery.getSelectedCustomLink),
     filter(rotation => rotation !== undefined)
   );
-  myCustomLinks$ = combineLatest(this.allCustomLinks$, this.authFacade.userId$).pipe(
+  myCustomLinks$ = combineLatest([this.allCustomLinks$, this.authFacade.userId$]).pipe(
     map(([folders, userId]) => folders.filter(folder => folder.authorId === userId)),
     shareReplay(1)
   );

--- a/apps/client/src/app/modules/freecompany-picker/user-picker/freecompany-picker.component.ts
+++ b/apps/client/src/app/modules/freecompany-picker/user-picker/freecompany-picker.component.ts
@@ -30,14 +30,14 @@ export class FreecompanyPickerComponent {
   constructor(private xivapi: XivapiService, private modalRef: NzModalRef) {
     this.servers$ = this.xivapi.getServerList().pipe(shareReplay(1));
 
-    this.autoCompleteRows$ = combineLatest(this.servers$, this.selectedServer.valueChanges)
+    this.autoCompleteRows$ = combineLatest([this.servers$, this.selectedServer.valueChanges])
       .pipe(
         map(([servers, inputValue]) => {
           return servers.filter(server => server.indexOf(inputValue) > -1);
         })
       );
 
-    this.result$ = combineLatest(this.selectedServer.valueChanges, this.fcName.valueChanges)
+    this.result$ = combineLatest([this.selectedServer.valueChanges, this.fcName.valueChanges])
       .pipe(
         tap(() => this.loadingResults = true),
         debounceTime(500),

--- a/apps/client/src/app/modules/layout-editor/layout-editor-row/layout-editor-row.component.ts
+++ b/apps/client/src/app/modules/layout-editor/layout-editor-row/layout-editor-row.component.ts
@@ -31,7 +31,7 @@ export class LayoutEditorRowComponent implements OnInit {
 
   tagInput$ = new BehaviorSubject<string>('');
 
-  availableTags$ = combineLatest(this.tagInput$, this.authFacade.user$).pipe(
+  availableTags$ = combineLatest([this.tagInput$, this.authFacade.user$]).pipe(
     map(([input, user]) => {
       return _.uniq(user.itemTags
         .filter(entry => entry.tag.toLowerCase().indexOf(input.toLowerCase()) > -1)

--- a/apps/client/src/app/modules/list-picker/list-picker-drawer/list-picker-drawer.component.ts
+++ b/apps/client/src/app/modules/list-picker/list-picker-drawer/list-picker-drawer.component.ts
@@ -64,7 +64,7 @@ export class ListPickerDrawerComponent {
       shareReplay(1)
     );
 
-    this.lists$ = combineLatest(this.listsFacade.loadingMyLists$, this.listsFacade.myLists$, this.workshops$, this.query$).pipe(
+    this.lists$ = combineLatest([this.listsFacade.loadingMyLists$, this.listsFacade.myLists$, this.workshops$, this.query$]).pipe(
       filter(([loading]) => !loading),
       debounceTime(100),
       map(([, lists, workshops, query]: [boolean, List[], WorkshopDisplay[], string]) => {

--- a/apps/client/src/app/modules/list/item/item-row/item-row.component.ts
+++ b/apps/client/src/app/modules/list/item/item-row/item-row.component.ts
@@ -562,7 +562,7 @@ export class ItemRowComponent extends TeamcraftComponent implements OnInit {
       mergeMap(list => {
         // We want to get the list created before calling it a success, let's be pessimistic !
         return this.progressService.showProgress(
-          combineLatest(this.listsFacade.myLists$, this.listsFacade.listsWithWriteAccess$).pipe(
+          combineLatest([this.listsFacade.myLists$, this.listsFacade.listsWithWriteAccess$]).pipe(
             map(([myLists, listsICanWrite]) => [...myLists, ...listsICanWrite]),
             map(lists => lists.find(l => l.createdAt.toMillis() === list.createdAt.toMillis() && l.$key !== undefined)),
             filter(l => l !== undefined),

--- a/apps/client/src/app/modules/list/list-details-panel/list-details-panel.component.ts
+++ b/apps/client/src/app/modules/list/list-details-panel/list-details-panel.component.ts
@@ -1,32 +1,40 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
-import { LayoutRowDisplay } from '../../../core/layout/layout-row-display';
-import { getItemSource, ListRow } from '../model/list-row';
-import { ZoneBreakdownRow } from '../../../model/common/zone-breakdown-row';
-import { I18nToolsService } from '../../../core/tools/i18n-tools.service';
-import { LocalizedDataService } from '../../../core/data/localized-data.service';
-import { I18nName } from '../../../model/common/i18n-name';
-import { NzMessageService, NzModalService } from 'ng-zorro-antd';
 import { TranslateService } from '@ngx-translate/core';
+import { NzMessageService, NzModalService } from 'ng-zorro-antd';
+import { ClipboardService } from 'ngx-clipboard';
+import { BehaviorSubject, combineLatest, concat, Observable, of } from 'rxjs';
+import { filter, first, map, mergeMap, switchMap, takeUntil, tap } from 'rxjs/operators';
+
+import { ListsFacade } from '../+state/lists.facade';
+import { AuthFacade } from '../../../+state/auth.facade';
+import { AlarmsFacade } from '../../../core/alarms/+state/alarms.facade';
+import { AlarmGroup } from '../../../core/alarms/alarm-group';
+import { GarlandToolsService } from '../../../core/api/garland-tools.service';
+import { UniversalisService } from '../../../core/api/universalis.service';
+import { LazyDataService } from '../../../core/data/lazy-data.service';
+import { LocalizedDataService } from '../../../core/data/localized-data.service';
+import { PermissionLevel } from '../../../core/database/permissions/permission-level.enum';
+import { LayoutOrderService } from '../../../core/layout/layout-order.service';
+import { LayoutRowDisplay } from '../../../core/layout/layout-row-display';
+import { I18nToolsService } from '../../../core/tools/i18n-tools.service';
+import { I18nName } from '../../../model/common/i18n-name';
 import { ZoneBreakdown } from '../../../model/common/zone-breakdown';
-import { TotalPanelPricePopupComponent } from '../../../pages/list-details/total-panel-price-popup/total-panel-price-popup.component';
+import { ZoneBreakdownRow } from '../../../model/common/zone-breakdown-row';
+import {
+  TotalPanelPricePopupComponent,
+} from '../../../pages/list-details/total-panel-price-popup/total-panel-price-popup.component';
+import { EorzeaFacade } from '../../eorzea/+state/eorzea.facade';
+import { VenturesComponent } from '../../item-details/ventures/ventures.component';
+import { ItemPickerService } from '../../item-picker/item-picker.service';
 import { NavigationMapComponent } from '../../map/navigation-map/navigation-map.component';
 import { NavigationObjective } from '../../map/navigation-objective';
-import { ListsFacade } from '../+state/lists.facade';
-import { PermissionLevel } from '../../../core/database/permissions/permission-level.enum';
-import { combineLatest, concat, Observable, of } from 'rxjs';
-import { ItemPickerService } from '../../item-picker/item-picker.service';
-import { filter, first, map, mergeMap, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { ListManagerService } from '../list-manager.service';
-import { ProgressPopupService } from '../../progress-popup/progress-popup.service';
-import { LayoutOrderService } from '../../../core/layout/layout-order.service';
 import { WorldNavigationMapComponent } from '../../map/world-navigation-map/world-navigation-map.component';
-import { EorzeaFacade } from '../../eorzea/+state/eorzea.facade';
-import { AlarmGroup } from '../../../core/alarms/alarm-group';
-import { AlarmsFacade } from '../../../core/alarms/+state/alarms.facade';
-import { DataType } from '../data/data-type';
+import { ProgressPopupService } from '../../progress-popup/progress-popup.service';
 import { SettingsService } from '../../settings/settings.service';
+import { DataType } from '../data/data-type';
+import { ListManagerService } from '../list-manager.service';
 import { Drop } from '../model/drop';
-import { LazyDataService } from '../../../core/data/lazy-data.service';
+import { getItemSource, ListRow } from '../model/list-row';
 
 @Component({
   selector: 'app-list-details-panel',

--- a/apps/client/src/app/modules/list/list-details-panel/list-details-panel.component.ts
+++ b/apps/client/src/app/modules/list/list-details-panel/list-details-panel.component.ts
@@ -1,40 +1,32 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
-import { NzMessageService, NzModalService } from 'ng-zorro-antd';
-import { ClipboardService } from 'ngx-clipboard';
-import { BehaviorSubject, combineLatest, concat, Observable, of } from 'rxjs';
-import { filter, first, map, mergeMap, switchMap, takeUntil, tap } from 'rxjs/operators';
-
-import { ListsFacade } from '../+state/lists.facade';
-import { AuthFacade } from '../../../+state/auth.facade';
-import { AlarmsFacade } from '../../../core/alarms/+state/alarms.facade';
-import { AlarmGroup } from '../../../core/alarms/alarm-group';
-import { GarlandToolsService } from '../../../core/api/garland-tools.service';
-import { UniversalisService } from '../../../core/api/universalis.service';
-import { LazyDataService } from '../../../core/data/lazy-data.service';
-import { LocalizedDataService } from '../../../core/data/localized-data.service';
-import { PermissionLevel } from '../../../core/database/permissions/permission-level.enum';
-import { LayoutOrderService } from '../../../core/layout/layout-order.service';
 import { LayoutRowDisplay } from '../../../core/layout/layout-row-display';
-import { I18nToolsService } from '../../../core/tools/i18n-tools.service';
-import { I18nName } from '../../../model/common/i18n-name';
-import { ZoneBreakdown } from '../../../model/common/zone-breakdown';
+import { getItemSource, ListRow } from '../model/list-row';
 import { ZoneBreakdownRow } from '../../../model/common/zone-breakdown-row';
-import {
-  TotalPanelPricePopupComponent,
-} from '../../../pages/list-details/total-panel-price-popup/total-panel-price-popup.component';
-import { EorzeaFacade } from '../../eorzea/+state/eorzea.facade';
-import { VenturesComponent } from '../../item-details/ventures/ventures.component';
-import { ItemPickerService } from '../../item-picker/item-picker.service';
+import { I18nToolsService } from '../../../core/tools/i18n-tools.service';
+import { LocalizedDataService } from '../../../core/data/localized-data.service';
+import { I18nName } from '../../../model/common/i18n-name';
+import { NzMessageService, NzModalService } from 'ng-zorro-antd';
+import { TranslateService } from '@ngx-translate/core';
+import { ZoneBreakdown } from '../../../model/common/zone-breakdown';
+import { TotalPanelPricePopupComponent } from '../../../pages/list-details/total-panel-price-popup/total-panel-price-popup.component';
 import { NavigationMapComponent } from '../../map/navigation-map/navigation-map.component';
 import { NavigationObjective } from '../../map/navigation-objective';
-import { WorldNavigationMapComponent } from '../../map/world-navigation-map/world-navigation-map.component';
-import { ProgressPopupService } from '../../progress-popup/progress-popup.service';
-import { SettingsService } from '../../settings/settings.service';
-import { DataType } from '../data/data-type';
+import { ListsFacade } from '../+state/lists.facade';
+import { PermissionLevel } from '../../../core/database/permissions/permission-level.enum';
+import { combineLatest, concat, Observable, of } from 'rxjs';
+import { ItemPickerService } from '../../item-picker/item-picker.service';
+import { filter, first, map, mergeMap, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { ListManagerService } from '../list-manager.service';
+import { ProgressPopupService } from '../../progress-popup/progress-popup.service';
+import { LayoutOrderService } from '../../../core/layout/layout-order.service';
+import { WorldNavigationMapComponent } from '../../map/world-navigation-map/world-navigation-map.component';
+import { EorzeaFacade } from '../../eorzea/+state/eorzea.facade';
+import { AlarmGroup } from '../../../core/alarms/alarm-group';
+import { AlarmsFacade } from '../../../core/alarms/+state/alarms.facade';
+import { DataType } from '../data/data-type';
+import { SettingsService } from '../../settings/settings.service';
 import { Drop } from '../model/drop';
-import { getItemSource, ListRow } from '../model/list-row';
+import { LazyDataService } from '../../../core/data/lazy-data.service';
 
 @Component({
   selector: 'app-list-details-panel',

--- a/apps/client/src/app/modules/list/list-panel/list-panel.component.ts
+++ b/apps/client/src/app/modules/list/list-panel/list-panel.component.ts
@@ -132,7 +132,7 @@ export class ListPanelComponent extends TeamcraftComponent {
               private router: Router, private layoutsFacade: LayoutsFacade, private layoutOrderService: LayoutOrderService,
               private cd: ChangeDetectorRef, public settings: SettingsService) {
     super();
-    this.customLink$ = combineLatest(this.customLinksFacade.myCustomLinks$, this.list$).pipe(
+    this.customLink$ = combineLatest([this.customLinksFacade.myCustomLinks$, this.list$]).pipe(
       map(([links, list]) => links.find(link => link.redirectTo === `list/${list.$key}`)),
       tap(link => link !== undefined ? this.syncLinkUrl = link.getUrl() : null),
       shareReplay(1)
@@ -140,7 +140,7 @@ export class ListPanelComponent extends TeamcraftComponent {
 
     this.teams$ = this.teamsFacade.myTeams$;
 
-    this.listTemplate$ = combineLatest(this.customLinksFacade.myCustomLinks$, this.list$).pipe(
+    this.listTemplate$ = combineLatest([this.customLinksFacade.myCustomLinks$, this.list$]).pipe(
       map(([links, list]) => {
         return <ListTemplate>links.find(link => {
           return link.type === 'template' && (<ListTemplate>link).originalListId === list.$key;
@@ -148,7 +148,7 @@ export class ListPanelComponent extends TeamcraftComponent {
       })
     );
 
-    this.listContent$ = combineLatest(this.list$, this.layoutsFacade.selectedLayout$).pipe(
+    this.listContent$ = combineLatest([this.list$, this.layoutsFacade.selectedLayout$]).pipe(
       map(([list, layout]) => {
         return this.layoutOrderService.order(list.finalItems, layout.recipeOrderBy, layout.recipeOrder);
       })

--- a/apps/client/src/app/modules/marketboard/marketboard-popup/marketboard-popup.component.ts
+++ b/apps/client/src/app/modules/marketboard/marketboard-popup/marketboard-popup.component.ts
@@ -75,7 +75,7 @@ export class MarketboardPopupComponent implements OnInit {
       })
     );
 
-    this.prices$ = combineLatest(data$
+    this.prices$ = combineLatest([data$
         .pipe(
           map(item => item.Prices),
           tap(() => this.loading = false),
@@ -86,7 +86,7 @@ export class MarketboardPopupComponent implements OnInit {
           }),
           shareReplay(1)
         ),
-      this.sort$
+      this.sort$]
     ).pipe(
       map(([prices, sort]) => {
         return [...prices.sort((a, b) => {

--- a/apps/client/src/app/modules/rotation-folders/+state/rotation-folders.facade.ts
+++ b/apps/client/src/app/modules/rotation-folders/+state/rotation-folders.facade.ts
@@ -30,13 +30,13 @@ export class RotationFoldersFacade {
     select(rotationFoldersQuery.getSelectedRotationFolder),
     filter(rotation => rotation !== undefined)
   );
-  myRotationFolders$ = combineLatest(this.allRotationFolders$, this.authFacade.userId$).pipe(
+  myRotationFolders$ = combineLatest([this.allRotationFolders$, this.authFacade.userId$]).pipe(
     map(([folders, userId]) => folders.filter(folder => folder.authorId === userId)
       .sort((a, b) => a.index - b.index))
   );
 
   favoriteRotationFolders$: Observable<{ folder: CraftingRotationsFolder, rotations: CraftingRotation[] }[]> =
-    combineLatest(this.allRotationFolders$, this.authFacade.favorites$, this.rotationsFacade.allRotations$).pipe(
+    combineLatest([this.allRotationFolders$, this.authFacade.favorites$, this.rotationsFacade.allRotations$]).pipe(
       map(([folders, favorites, rotations]) => {
         (favorites.rotationFolders || []).forEach(folder => {
           if (folders.find(f => f.$key === folder) === undefined) {

--- a/apps/client/src/app/modules/rotations/+state/rotations.facade.ts
+++ b/apps/client/src/app/modules/rotations/+state/rotations.facade.ts
@@ -23,7 +23,7 @@ import { DefaultConsumables } from '../../../model/user/default-consumables';
 export class RotationsFacade {
   loading$ = this.store.select(rotationsQuery.getLoading);
   allRotations$ = this.store.select(rotationsQuery.getAllRotations);
-  myRotations$ = combineLatest(this.allRotations$, this.authFacade.userId$).pipe(
+  myRotations$ = combineLatest([this.allRotations$, this.authFacade.userId$]).pipe(
     map(([rotations, userId]) => rotations.filter(r => r.authorId === userId)),
     map(rotations => rotations.sort((a, b) => a.index - b.index))
   );

--- a/apps/client/src/app/modules/teams/+state/teams.facade.ts
+++ b/apps/client/src/app/modules/teams/+state/teams.facade.ts
@@ -17,7 +17,7 @@ export class TeamsFacade {
   loading$ = this.store.select(teamsQuery.getLoaded).pipe(map(loaded => !loaded));
   allTeams$ = this.store.select(teamsQuery.getAllTeams);
   selectedTeam$ = this.store.select(teamsQuery.getSelectedTeam);
-  myTeams$ = combineLatest(this.allTeams$, this.authFacade.userId$).pipe(
+  myTeams$ = combineLatest([this.allTeams$, this.authFacade.userId$]).pipe(
     map(([teams, userId]) => {
       return teams.filter(team => !team.notFound && team.members.indexOf(userId) > -1);
     })

--- a/apps/client/src/app/modules/workshop/+state/workshops.effects.ts
+++ b/apps/client/src/app/modules/workshop/+state/workshops.effects.ts
@@ -65,13 +65,13 @@ export class WorkshopsEffects {
     switchMap((action: LoadWorkshop) => {
       return this.authFacade.loggedIn$.pipe(
         switchMap(loggedIn => {
-          return combineLatest(
+          return combineLatest([
             of(action.key),
             loggedIn ? this.authFacade.user$ : of(null),
             this.authFacade.userId$,
             loggedIn ? this.authFacade.mainCharacter$.pipe(map(c => c.FreeCompanyId)) : of(null),
             this.workshopService.get(action.key).pipe(catchError(() => of(null)))
-          );
+          ]);
         })
       );
     }),

--- a/apps/client/src/app/pages/custom-items/custom-items/custom-items.component.ts
+++ b/apps/client/src/app/pages/custom-items/custom-items/custom-items.component.ts
@@ -45,7 +45,7 @@ export class CustomItemsComponent {
 
   public display$: Observable<CustomItemsDisplay> = this.customItemsFacade.customItemsDisplay$;
 
-  public loading$: Observable<boolean> = combineLatest(this.customItemsFacade.loaded$, this.customItemsFacade.foldersLoaded$).pipe(
+  public loading$: Observable<boolean> = combineLatest([this.customItemsFacade.loaded$, this.customItemsFacade.foldersLoaded$]).pipe(
     map(([itemsLoaded, foldersLoaded]) => !itemsLoaded || !foldersLoaded)
   );
 
@@ -282,7 +282,7 @@ export class CustomItemsComponent {
       mergeMap(list => {
         // We want to get the list created before calling it a success, let's be pessimistic !
         return this.progressService.showProgress(
-          combineLatest(this.listsFacade.myLists$, this.listsFacade.listsWithWriteAccess$).pipe(
+          combineLatest([this.listsFacade.myLists$, this.listsFacade.listsWithWriteAccess$]).pipe(
             map(([myLists, listsICanWrite]) => [...myLists, ...listsICanWrite]),
             map(lists => lists.find(l => l.createdAt.toMillis() === list.createdAt.toMillis() && l.$key !== undefined)),
             filter(l => l !== undefined),

--- a/apps/client/src/app/pages/db/node/node.component.ts
+++ b/apps/client/src/app/pages/db/node/node.component.ts
@@ -71,11 +71,11 @@ export class NodeComponent extends TeamcraftPageComponent {
         if (!(base.GameContentLinks && base.GameContentLinks.GatheringPoint)) {
           return of(base);
         }
-        return combineLatest(base.GameContentLinks.GatheringPoint.GatheringPointBase.map(
+        return combineLatest([base.GameContentLinks.GatheringPoint.GatheringPointBase.map(
           point => {
             return this.xivapi.get(XivapiEndpoint.GatheringPoint, point);
           }
-        )).pipe(
+        )]).pipe(
           map(points => {
             base.GatheringPoints = points;
             return base;

--- a/apps/client/src/app/pages/desynth/desynth/desynth.component.ts
+++ b/apps/client/src/app/pages/desynth/desynth/desynth.component.ts
@@ -210,7 +210,7 @@ export class DesynthComponent {
       mergeMap(list => {
         // We want to get the list created before calling it a success, let's be pessimistic !
         return this.progressService.showProgress(
-          combineLatest(this.listsFacade.myLists$, this.listsFacade.listsWithWriteAccess$).pipe(
+          combineLatest([this.listsFacade.myLists$, this.listsFacade.listsWithWriteAccess$]).pipe(
             map(([myLists, listsICanWrite]) => [...myLists, ...listsICanWrite]),
             map(lists => lists.find(l => l.createdAt.toMillis() === list.createdAt.toMillis() && l.$key !== undefined)),
             filter(l => l !== undefined),

--- a/apps/client/src/app/pages/log-tracker/fishing-log-tracker/fishing-log-tracker.component.ts
+++ b/apps/client/src/app/pages/log-tracker/fishing-log-tracker/fishing-log-tracker.component.ts
@@ -312,11 +312,11 @@ export class FishingLogTrackerComponent extends TrackerComponent implements OnIn
       shareReplay(1)
     );
 
-    this.tabsDisplay$ = combineLatest(this.display$, this.type$).pipe(
+    this.tabsDisplay$ = combineLatest([this.display$, this.type$]).pipe(
       map(([display, type]) => display[type])
     );
 
-    this.pageDisplay$ = combineLatest(this.tabsDisplay$, this.spotId$).pipe(
+    this.pageDisplay$ = combineLatest([this.tabsDisplay$, this.spotId$]).pipe(
       map(([display, spotId]) => {
         const area = display.tabs.find(a => a.spots.some(spot => spot.id === spotId));
         if (area !== undefined) {

--- a/apps/client/src/app/pages/log-tracker/log-tracker/log-tracker.component.ts
+++ b/apps/client/src/app/pages/log-tracker/log-tracker/log-tracker.component.ts
@@ -127,7 +127,7 @@ export class LogTrackerComponent extends TrackerComponent {
       mergeMap(list => {
         // We want to get the list created before calling it a success, let's be pessimistic !
         return this.progressService.showProgress(
-          combineLatest(this.listsFacade.myLists$, this.listsFacade.listsWithWriteAccess$).pipe(
+          combineLatest([this.listsFacade.myLists$, this.listsFacade.listsWithWriteAccess$]).pipe(
             map(([myLists, listsICanWrite]) => [...myLists, ...listsICanWrite]),
             map(lists => lists.find(l => l.createdAt.toMillis() === list.createdAt.toMillis() && l.$key !== undefined)),
             filter(l => l !== undefined),

--- a/apps/client/src/app/pages/simulator/components/rotation-panel/rotation-panel.component.ts
+++ b/apps/client/src/app/pages/simulator/components/rotation-panel/rotation-panel.component.ts
@@ -55,7 +55,7 @@ export class RotationPanelComponent implements OnInit {
 
   actions$: Observable<CraftingAction[]>;
 
-  permissionLevel$: Observable<PermissionLevel> = combineLatest(this.rotation$, this.authFacade.userId$).pipe(
+  permissionLevel$: Observable<PermissionLevel> = combineLatest([this.rotation$, this.authFacade.userId$]).pipe(
     map(([rotation, userId]) => rotation.getPermissionLevel(userId))
   );
 
@@ -95,7 +95,7 @@ export class RotationPanelComponent implements OnInit {
       map(rotation => this.registry.deserializeRotation(rotation.rotation))
     );
 
-    this.customLink$ = combineLatest(this.customLinksFacade.myCustomLinks$, this.rotation$).pipe(
+    this.customLink$ = combineLatest([this.customLinksFacade.myCustomLinks$, this.rotation$]).pipe(
       filter(([, rotation]) => rotation !== null),
       map(([links, rotation]) => links.find(link => link.redirectTo === this.getRouterLink(rotation).substr(1))),
       tap(link => link !== undefined ? this.syncLinkUrl = link.getUrl() : null),
@@ -109,7 +109,7 @@ export class RotationPanelComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.simulation$ = combineLatest(this.rotation$, this.authFacade.gearSets$, this.simulationSet$).pipe(
+    this.simulation$ = combineLatest([this.rotation$, this.authFacade.gearSets$, this.simulationSet$]).pipe(
       filter(([rotation, , stats]) => rotation !== null && stats !== null),
       map(([rotation, gearSets, stats]) => {
         const food = this.foods.find(f => this.rotation.food && f.itemId === this.rotation.food.id && f.hq === this.rotation.food.hq);


### PR DESCRIPTION
```
Ivan Lloyd@OKame MINGW64 /e/ffxiv-teamcraft (style/combineLatestLint)
$ yarn lint | grep combineLatest

Could not find implementations for the following rules specified in the configuration:
    use-input-property-decorator
    use-output-property-decorator
    use-host-property-decorator
Try upgrading TSLint and/or ensuring that you have all necessary custom rules installed.
If TSLint was recently upgraded, you may have old rules configured which need to be cleaned up.

Lint warnings found in the listed files.
```