### PR TITLE
Fix/smart quotes in macro translator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,12 @@ Simply run `npm start` to start a live server with file watcher.
 
 ### Branch names
 
-When contributing to main repository, you'll notice that branche names follow a given pattern,
+When contributing to main repository, you'll notice that branch names follow a given pattern,
 this pattern is the following: `<branch-type>/<short-description>`.
 
 Example: `feat/commission-history-tab` would be a branch that adds a commission history tab.
 
-We're using gitflow for this, more informations on [https://github.com/nvie/gitflow](https://github.com/nvie/gitflow)
+We're using gitflow for this, more information on [https://github.com/nvie/gitflow](https://github.com/nvie/gitflow)
 
 ### Commit Messages
  The commit messages are checked by a pre-commit git hook, meaning that if they don't meet the requirements, 
@@ -93,7 +93,7 @@ We're using gitflow for this, more informations on [https://github.com/nvie/gitf
 
 Teamcraft has some tests to ensure non regression, you might want to implement more tests instead of creating some features, to help with application reliability, to make sure nothing breaks with a given update.
 
-Test are separated into two categories, Unit and End-to-End.
+Tests are separated into two categories, Unit and End-to-End.
 
 ### Unit tests
 
@@ -107,7 +107,7 @@ To run unit tests, use `npm test`.
 
 End-to-end tests (e2e) are here to make sure that the end user integration is good, they are here to reproduce user behavior and expect given results.
 
-They are pretty muched used as integration tests in our case, because implementing them properly is easier than doing integration tests using karma runner.
+They are pretty much used as integration tests in our case, because implementing them properly is easier than doing integration tests using karma runner.
 
 E2e tests are using [cypress](https://www.cypress.io/), a nice library that has some features such as time travelling for debugging purpose, video recording, selector generator (to find quickly how to match a given element) and is way faster than most of the selenium wrappers.
 

--- a/apps/client-e2e/src/integration/pages/macro-translator/macro-translator/macro-translator.component.spec.ts
+++ b/apps/client-e2e/src/integration/pages/macro-translator/macro-translator/macro-translator.component.spec.ts
@@ -1,0 +1,35 @@
+import { setLanguage, preventModals, loadRoute } from '../../../../support/app.po';
+
+describe('Macro translator tests', () => {
+  before(() => {
+    indexedDB.deleteDatabase('firebaseLocalStorageDb');
+    preventModals();
+    setLanguage('EN');
+
+    loadRoute('/macro-translator');
+  });
+
+  it('should be able to deal with normal quotes', () => {
+    cy.get('label[ng-reflect-nz-value="en"]').should('be.visible');
+    cy.get('label[ng-reflect-nz-value="en"]').click();
+    cy.get('textarea.ant-input').should('be.visible');
+    cy.get('textarea.ant-input').type('/ac "Inner quiet" <me><wait.2>');
+
+    cy.get('button').should('be.visible').should('have.text', 'Translate !').first().click();
+
+    cy.get('div.ant-tabs-tab').should('be.visible').contains('EN').click();
+    cy.get('div.ant-tabs-content .ant-tabs-tabpane span').should('have.text', '/ac "Inner Quiet" <me><wait.2>');
+  });
+
+  it('should be able to deal with smart quotes', () => {
+    cy.get('label[ng-reflect-nz-value="en"]').should('be.visible');
+    cy.get('label[ng-reflect-nz-value="en"]').click();
+    cy.get('textarea.ant-input').should('be.visible');
+    cy.get('textarea.ant-input').clear().type('/ac “Inner quiet” <me><wait.2>');
+
+    cy.get('button').should('be.visible').should('have.text', 'Translate !').first().click();
+
+    cy.get('div.ant-tabs-tab').should('be.visible').contains('EN').click();
+    cy.get('div.ant-tabs-content .ant-tabs-tabpane span').should('have.text', '/ac "Inner Quiet" <me><wait.2>');
+  });
+});

--- a/apps/client-e2e/src/support/app.po.ts
+++ b/apps/client-e2e/src/support/app.po.ts
@@ -1,5 +1,24 @@
 export const getPageTitle = () => cy.get('a.logo');
 
+// Loads a given route, waits for necessary routes to be loaded first though
+export const loadRoute = (route: string) => {
+  cy.server();
+  cy.route('assets/**').as('assets');
+  cy.route('servers/dc').as('servers');
+  cy.route('patchlist').as('patchlist');
+  cy.route('db/**').as('database');
+  cy.route('sockjs-node/**').as('nodejs');
+  cy.route({
+    method: 'POST',
+    url: 'identitytoolkit/**'
+  }).as('toolkit');
+
+  cy.visit(route);
+  cy.wait(['@assets', '@servers', '@patchlist', '@database', '@nodejs', '@toolkit']);
+  cy.wait(2000);
+};
+
+// Manual click way to change the language, must be executed **after** `cy.visit`
 export const changeLanguage = (newLanguage: 'EN' | 'DE' | 'FR' | 'JA' | 'PT' | 'BR' | 'ES' | 'KO' | 'ZH') => {
   const index = ['EN', 'DE', 'FR', 'JA', 'PT', 'BR', 'ES', 'KO', 'ZH'].indexOf(newLanguage) + 1;
   cy.get('.language-swap > .ant-select-selection').click({ multiple: true, force: true });
@@ -7,3 +26,10 @@ export const changeLanguage = (newLanguage: 'EN' | 'DE' | 'FR' | 'JA' | 'PT' | '
 };
 
 export const toggleSider = () => cy.get('.ant-layout-sider-trigger').click();
+
+export const preventModals = () => window.localStorage.setItem('settings', '{"last-changes-seen":"99.9.9"}');
+
+// Changes language via localStorage, must be executed **before** `cy.visit`
+export const setLanguage = (newLanguage: 'EN' | 'DE' | 'FR' | 'JA' | 'PT' | 'BR' | 'ES' | 'KO' | 'ZH') => {
+  window.localStorage.setItem('locale', newLanguage.toLowerCase());
+};

--- a/apps/client/src/app/pages/macro-translator/macro-translator/macro-translator.component.html
+++ b/apps/client/src/app/pages/macro-translator/macro-translator/macro-translator.component.html
@@ -13,9 +13,7 @@
             rows="4"></textarea>
   </div>
 
-  <button (click)="translateMacro()" *ngIf="macroToTranslate" nz-button nzType="primary">
-    {{'MACRO_TRANSLATION.Do_translate' | translate}}
-  </button>
+  <button (click)="translateMacro()" *ngIf="macroToTranslate" nz-button nzType="primary">{{'MACRO_TRANSLATION.Do_translate' | translate}}</button>
 
   <nz-tabset *ngIf="!invalidInputs && translationDone">
     <nz-tab *ngFor="let macroTranslatedTab of macroTranslatedTabs" [nzTitle]="macroTranslatedTab.label">

--- a/apps/client/src/app/pages/macro-translator/macro-translator/macro-translator.component.ts
+++ b/apps/client/src/app/pages/macro-translator/macro-translator/macro-translator.component.ts
@@ -25,7 +25,7 @@ export class MacroTranslatorComponent {
   ];
 
   private findActionsRegex: RegExp =
-    new RegExp(/\/(ac|action|aaction|gaction|generalaction|statusoff)[\s]+((\w|[éàèç]|[\u3000-\u303F]|[\u3040-\u309F]|[\u30A0-\u30FF]|[\uFF00-\uFFEF]|[\u4E00-\u9FAF]|[\u2605-\u2606]|[\u2190-\u2195]|\u203B)+|"[^"]+")?.*/, 'i');
+    new RegExp(/\/(ac|action|aaction|gaction|generalaction|statusoff)[\s]+((\w|[éàèç]|[\u3000-\u303F]|[\u3040-\u309F]|[\u30A0-\u30FF]|[\uFF00-\uFFEF]|[\u4E00-\u9FAF]|[\u2605-\u2606]|[\u2190-\u2195]|\u203B)+|["”“][^"”“]+["”“])?.*/, 'i');
 
 
   private findActionsAutoTranslatedRegex: RegExp =
@@ -48,16 +48,18 @@ export class MacroTranslatorComponent {
 
     this.translationDone = false;
     this.invalidInputs = false;
-    for (const line of this.macroToTranslate.split('\n')) {
+    for (let line of this.macroToTranslate.split('\n')) {
       let match = this.findActionsRegex.exec(line);
       if (match !== null && match !== undefined) {
-        const skillName = match[2].replace(/"/g, '');
+        const skillName = match[2].replace(/["”“]/g, '');
         // Get translated skill
         try {
           const translatedSkill = this.localizedDataService.getCraftingActionByName(skillName, this.macroLanguage);
           // Push translated line to each language
           Object.keys(macroTranslated).forEach(key => {
             if (translatedSkill[key] !== undefined) {
+              // Get rid of smart quotes
+              line = line.replace(/[”“]/g, '"');
               if (((key === 'ko' || key === 'zh') && line.indexOf('"') === -1) || (translatedSkill[key].indexOf(' ') > -1 && line.indexOf('"') === -1)) {
                 macroTranslated[key].push(line.replace(skillName, `"${translatedSkill[key]}"`));
               } else {


### PR DESCRIPTION
The macro translator fails (silently, just a console error) when using smart quotes, such as:
```
// Smart quotes
/ac “Inner quiet” <me><wait.2>
// Normal quotes for comparison
/ac "Inner quiet" <me><wait.2>
```

This PR adds support for those smart quotes, as well as an e2e test for that case.