### PR TITLE
Move alarm group delete buttons into dropdown

### DIFF
--- a/apps/client/src/app/pages/alarms-page/alarms-page/alarms-page.component.html
+++ b/apps/client/src/app/pages/alarms-page/alarms-page/alarms-page.component.html
@@ -86,13 +86,36 @@
                       nzSize="small">
                 <i nz-icon nzType="edit"></i>
               </button>
-              <button (click)="$event.stopPropagation();" (nzOnConfirm)="deleteGroup(group.group)"
-                      [nzPopconfirmTitle]="'ALARMS.Confirm_group_delete' | translate"
-                      nz-button nz-popconfirm
+              <button (click)="$event.stopPropagation();" 
+                      [nzDropdownMenu]="menu"
+                      nz-button
+                      nz-dropdown
                       nzGhost
-                      nzShape="circle" nzSize="small">
+                      nzTrigger="click"
+                      nzShape="circle" nzSize="small"
+               >
                 <i nz-icon nzType="delete"></i>
               </button>
+              <nz-dropdown-menu #menu="nzDropdownMenu" >
+                <ul nz-menu>
+                    <li nz-menu-item>
+                      <a (nzOnConfirm)="deleteGroup(group.group)"
+                        [nzPopconfirmTitle]="'ALARMS.Confirm_group_delete' | translate"
+                        nz-popconfirm
+                      >
+                        {{'ALARMS.Delete_group' | translate}}
+                      </a>
+                    </li>
+                    <li nz-menu-item>
+                      <a (nzOnConfirm)="deleteGroupAndAlarms(group.group, group.alarms)"
+                        [nzPopconfirmTitle]="'ALARMS.Confirm_group_delete_with_alarms' | translate"
+                        nz-popconfirm
+                      >
+                        {{'ALARMS.Delete_group_and_alarms' | translate}}
+                      </a>
+                    </li>
+                </ul>
+              </nz-dropdown-menu>
               <button (click)="$event.stopPropagation(); addAlarmsToGroup(group.group)" [nzShape]="'circle'"
                       [nzTitle]="'ALARMS.Add_alarms_to_group' | translate"
                       [nzType]="'primary'" nz-button nz-tooltip
@@ -100,14 +123,6 @@
                 <i nz-icon nzType="plus"></i>
               </button>
               <div class="spacer"></div>
-              <button (click)="$event.stopPropagation();" (nzOnConfirm)="deleteGroupAndAlarms(group.group, group.alarms)"
-                      [nzPopconfirmTitle]="'ALARMS.Confirm_group_delete_with_alarms' | translate"
-                      nz-button
-                      nz-popconfirm
-                      nzSize="small"
-                      nzType="danger">
-                {{'ALARMS.Delete_group_and_alarms' | translate}}
-              </button>
               <nz-switch (click)="$event.stopPropagation();"
                          [(ngModel)]="group.group.enabled"
                          (ngModelChange)="updateGroupMuteState(group.group)"></nz-switch>

--- a/apps/client/src/assets/i18n/de-DE.json
+++ b/apps/client/src/assets/i18n/de-DE.json
@@ -177,6 +177,7 @@
     "Custom_sound": "Benutzerdefinierter Benachrichtigungston",
     "New_group": "Neue Benachrichtigungsgruppe",
     "Confirm_group_delete": "Möchtest du diese Gruppe wirklich löschen?",
+    "Delete_group": "Gruppe löschen",
     "Delete_group_and_alarms": "Gruppe mit allen Alarmen löschen",
     "Confirm_group_delete_with_alarms": "Möchtest du diese Gruppe und alle Alarme darin wirklich löschen?",
     "Add_note": "Notiz hinzufügen",

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -177,6 +177,7 @@
     "Custom_sound": "Custom alarm sound",
     "New_group": "New alarm group",
     "Confirm_group_delete": "Are you sure you want to delete this group?",
+    "Delete_group": "Delete group",
     "Delete_group_and_alarms": "Delete group with all alarms",
     "Confirm_group_delete_with_alarms": "Are you sure you want to delete this group and all the alarms inside of it?",
     "Add_note": "Add a note",

--- a/apps/client/src/assets/i18n/es-ES.json
+++ b/apps/client/src/assets/i18n/es-ES.json
@@ -177,6 +177,7 @@
     "Custom_sound": "Sonido de alarma personalizado",
     "New_group": "Nuevo grupo de alarmas",
     "Confirm_group_delete": "¿Está seguro de que quiere eliminar este grupo?",
+    "Delete_group": "Eliminar grupo",
     "Delete_group_and_alarms": "Eliminar grupo con todas las alarmas",
     "Confirm_group_delete_with_alarms": "¿Está seguro que desea eliminar este grupo y todas sus alarmas?",
     "Add_note": "Agregar una nota",

--- a/apps/client/src/assets/i18n/fr-FR.json
+++ b/apps/client/src/assets/i18n/fr-FR.json
@@ -177,6 +177,7 @@
     "Custom_sound": "Son d'alarme personnalisé",
     "New_group": "Nouveau groupe d’alarmes",
     "Confirm_group_delete": "Êtes-vous sûr de vouloir supprimer ce groupe ?",
+    "Delete_group": "Supprimer le groupe",
     "Delete_group_and_alarms": "Supprimer le groupe avec toutes les alarmes",
     "Confirm_group_delete_with_alarms": "Êtes-vous sûr de vouloir supprimer ce groupe et toutes les alarmes à l’intérieur ?",
     "Add_note": "Ajouter une note",

--- a/apps/client/src/assets/i18n/hr-HR.json
+++ b/apps/client/src/assets/i18n/hr-HR.json
@@ -177,6 +177,7 @@
     "Custom_sound": "Prilagođen zvuk alarma",
     "New_group": "Nova grupa alarma",
     "Confirm_group_delete": "Are you sure you want to delete this group?",
+    "Delete_group": "Delete group",
     "Delete_group_and_alarms": "Delete group with all alarms",
     "Confirm_group_delete_with_alarms": "Are you sure you want to delete this group and all the alarms inside of it?",
     "Add_note": "Dodajte bilješku",

--- a/apps/client/src/assets/i18n/ja-JP.json
+++ b/apps/client/src/assets/i18n/ja-JP.json
@@ -177,6 +177,7 @@
     "Custom_sound": "カスタムアラート音",
     "New_group": "新しいアラームグループ",
     "Confirm_group_delete": "本当にこのグループを削除しますか？",
+    "Delete_group": "Delete group",
     "Delete_group_and_alarms": "グループ内のすべてのアラームを消す",
     "Confirm_group_delete_with_alarms": "本当にこのグループや全てのアラームを削除しますか？",
     "Add_note": "メモを追加する",

--- a/apps/client/src/assets/i18n/ko-KR.json
+++ b/apps/client/src/assets/i18n/ko-KR.json
@@ -177,6 +177,7 @@
     "Custom_sound": "알람소리 사용자 지정",
     "New_group": "새로운 알람 그룹",
     "Confirm_group_delete": "정말 이 그룹을 삭제하시겠습니까?",
+    "Delete_group": "Delete group",
     "Delete_group_and_alarms": "그룹과 그룹 내 모든 알람 지우기",
     "Confirm_group_delete_with_alarms": "정말로 이 그룹과 그 안에 있는 알람을 지우시겠습니까?",
     "Add_note": "메모 추가",

--- a/apps/client/src/assets/i18n/nl-NL.json
+++ b/apps/client/src/assets/i18n/nl-NL.json
@@ -177,6 +177,7 @@
     "Custom_sound": "Custom alarm sound",
     "New_group": "New alarm group",
     "Confirm_group_delete": "Are you sure you want to delete this group?",
+    "Delete_group": "Delete group",
     "Delete_group_and_alarms": "Delete group with all alarms",
     "Confirm_group_delete_with_alarms": "Are you sure you want to delete this group and all the alarms inside of it?",
     "Add_note": "Add a note",

--- a/apps/client/src/assets/i18n/pt-BR.json
+++ b/apps/client/src/assets/i18n/pt-BR.json
@@ -177,6 +177,7 @@
     "Custom_sound": "Som do alarme personalizado",
     "New_group": "Novo grupo de alarmes",
     "Confirm_group_delete": "Tem certeza que deseja eliminar este grupo?",
+    "Delete_group": "Delete group",
     "Delete_group_and_alarms": "Delete group with all alarms",
     "Confirm_group_delete_with_alarms": "Tem a certeza que deseja eliminar este grupo e todos os seus alarmes?",
     "Add_note": "Adicionar uma nota",

--- a/apps/client/src/assets/i18n/pt-PT.json
+++ b/apps/client/src/assets/i18n/pt-PT.json
@@ -177,6 +177,7 @@
     "Custom_sound": "Som do alarme personalizado",
     "New_group": "Novo grupo de alarmes",
     "Confirm_group_delete": "Tem certeza que deseja eliminar este grupo?",
+    "Delete_group": "Eliminar grupo",
     "Delete_group_and_alarms": "Eliminar grupo com todos os alarmes",
     "Confirm_group_delete_with_alarms": "Tem a certeza que deseja eliminar este grupo e todos os seus alarmes?",
     "Add_note": "Adicionar uma nota",

--- a/apps/client/src/assets/i18n/ru-RU.json
+++ b/apps/client/src/assets/i18n/ru-RU.json
@@ -177,6 +177,7 @@
     "Custom_sound": "Настраиваемый звук",
     "New_group": "Новая группа оповещений",
     "Confirm_group_delete": "Вы действительно хотите удалить эту группу?",
+    "Delete_group": "Delete group",
     "Delete_group_and_alarms": "Удалить группу со всеми оповещениями",
     "Confirm_group_delete_with_alarms": "Вы уверены, что хотите удалить эту группу и все её оповещения?",
     "Add_note": "Добавить заметку",

--- a/apps/client/src/assets/i18n/zh-CN.json
+++ b/apps/client/src/assets/i18n/zh-CN.json
@@ -177,6 +177,7 @@
     "Custom_sound": "自定义闹钟声音",
     "New_group": "新建闹钟组",
     "Confirm_group_delete": "确定要删除这个分组吗？",
+    "Delete_group": "Delete group",
     "Delete_group_and_alarms": "删除该分组和分组下的所有闹钟",
     "Confirm_group_delete_with_alarms": "您确定要删除此组及其中的所有闹钟吗？",
     "Add_note": "添加备注",


### PR DESCRIPTION
This PR moves the buttons to delete a alarm-group into a dropdown.

fixes #1646

--
Unfortunately i was not sure how to translate some languages.