### PR TITLE
feat: proper zoom handling in desktop app

### DIFF
--- a/apps/client/src/app/app.component.ts
+++ b/apps/client/src/app/app.component.ts
@@ -195,6 +195,13 @@ export class AppComponent implements OnInit {
       this.router.navigateByUrl('/admin/users');
     });
 
+    // Scuff Zoom Handling
+    document.addEventListener("keydown", event => {
+      if (event.ctrlKey && [187, 107].includes(event.keyCode)) {
+        return this.ipc.send('zoom-in', event)
+      }
+    });
+
     const link = httpLink.create({ uri: 'https://us-central1-ffxivteamcraft.cloudfunctions.net/gubal-proxy' });
 
     apollo.create({

--- a/apps/client/src/environments/patch-notes.ts
+++ b/apps/client/src/environments/patch-notes.ts
@@ -13,4 +13,4 @@ export const patchNotes = `### Bug Fixes
 
 ### Features
 
-* **patreon:** new supporter: Coss Collaborative..`;
+* **patreon:** new supporter: Coss Collaborative..`;

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -855,9 +855,7 @@ ipcMain.on('navigated', (event, uri) => {
 });
 
 ipcMain.on('zoom-in', () => {
-    console.log('CommandOrControl+= is pressed')
     var currentzoom = win.webContents.getZoomLevel()
-    console.log(currentzoom++)
     win.webContents.setZoomLevel(currentzoom++)
 })
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -854,6 +854,13 @@ ipcMain.on('navigated', (event, uri) => {
   deepLink = uri;
 });
 
+ipcMain.on('zoom-in', () => {
+    console.log('CommandOrControl+= is pressed')
+    var currentzoom = win.webContents.getZoomLevel()
+    console.log(currentzoom++)
+    win.webContents.setZoomLevel(currentzoom++)
+})
+
 // Oauth stuff
 ipcMain.on('oauth', (event, providerId) => {
   if (providerId === 'google.com') {


### PR DESCRIPTION
Addressed #1643 I feel like it's kind of scuff but I added somewhat proper zoom handling. The following checks for ``CTRL`` + ``=``(on number row) or ``+``(on numpad) to begin zoom in and sends it to main process.

```ts
// Scuff Zoom Handling
document.addEventListener("keydown", event => {
  if (event.ctrlKey && [187, 107].includes(event.keyCode)) {
    return this.ipc.send('zoom-in', event)
  }
});
```
The main process is just gonna do simple maffs to increase zoomlevel.
```ts
ipcMain.on('zoom-in', () => {
    var currentzoom = win.webContents.getZoomLevel()
    win.webContents.setZoomLevel(currentzoom++)
})
```