### PR TITLE
fix(list-details): large panels are now collapsed by default, instead of entire list

### DIFF
--- a/apps/client/src/app/modules/list/list-details-panel/list-details-panel.component.ts
+++ b/apps/client/src/app/modules/list/list-details-panel/list-details-panel.component.ts
@@ -67,13 +67,12 @@ export class ListDetailsPanelComponent implements OnChanges, OnInit {
   finalItems = false;
 
   @Input()
-  collapsed = false;
-
-  @Input()
   overlay = false;
 
   @Input()
   largeList = false;
+
+  collapsed = false;
 
   progression: number;
 
@@ -154,6 +153,8 @@ export class ListDetailsPanelComponent implements OnChanges, OnInit {
 
   ngOnInit(): void {
     if (this.displayRow && this.displayRow.collapsedByDefault) {
+      this.collapsed = true;
+    } else if (this.displayRow && this.displayRow.rows.length > 25) {
       this.collapsed = true;
     }
   }
@@ -469,7 +470,7 @@ export class ListDetailsPanelComponent implements OnChanges, OnInit {
     return rows.reduce((exportString, row) => {
       return exportString + `${row.amount}x ${this.i18nTools.getName(this.l12n.getItem(row.id))}\n`;
     }, `${this.displayRow.title} :\n`);
-  }
+  };
 
   trackByItem(index: number, item: ListRow): number {
     return item.id;

--- a/apps/client/src/app/pages/list-details/list-details/list-details.component.html
+++ b/apps/client/src/app/pages/list-details/list-details/list-details.component.html
@@ -282,7 +282,6 @@
           <app-list-crystals-panel *ngIf="listDisplay.crystalsPanel"
                                    [crystals]="crystals$ | async"></app-list-crystals-panel>
           <app-list-details-panel *ngFor="let displayRow of listDisplay.rows; trackBy: trackByDisplayRow"
-                                  [collapsed]="listIsLarge"
                                   [largeList]="listIsLarge"
                                   [displayRow]="displayRow"></app-list-details-panel>
           <app-list-details-panel *ngIf="listDisplay.showFinalItemsPanel"


### PR DESCRIPTION
#1609 