### PR TITLE
CHORE: Adjust color of step state 'poor'

### DIFF
--- a/apps/client/src/app/pages/simulator/components/action/action.component.ts
+++ b/apps/client/src/app/pages/simulator/components/action/action.component.ts
@@ -113,7 +113,7 @@ export class ActionComponent {
       case StepState.CENTERED:
         return 'yellow';
       case StepState.POOR:
-        return 'purple';
+        return 'violet';
     }
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59393535/102699320-51d53c00-4209-11eb-8425-f89e1eb2caf0.png)

The current choice of color for the state 'poor' has poor visibility against the default tooltip background color of #282828, which could cause issues for those with weak or color-compromised eyesight. 

I propose that the color 'purple' be changed to 'violet' instead. It matches the ingame color used for the state, as pictured here:
![image](https://user-images.githubusercontent.com/59393535/102699362-b85a5a00-4209-11eb-8467-425b02529a26.png)

In addition, it has better legibility across the Teamcraft app without changing the aesthetic dramatically.
![image](https://user-images.githubusercontent.com/59393535/102699390-e344ae00-4209-11eb-8279-36bcdd1e1bf4.png)
