### PR TITLE
7.6.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="7.6.14"></a>
+## [7.6.14](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/compare/v7.6.12...v7.6.14) (2020-12-24)
+
+
+### Bug Fixes
+
+* **db:** fixed coords for a lot of monsters and nodes ([5642020](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/5642020))
+* **desktop:** fixed crafting replay not recording and various machina issues ([ae6467e](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/ae6467e))
+* **inventory-optimizer:** hovering sidebar elements no longer makes the app slow ([c72f2ce](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/c72f2ce))
+* **layout:** hotfix for new npc breakdown system ([e630ce7](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/e630ce7))
+* **log-tracker:** fixed small layout issue with some resolutions ([369f969](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/369f969))
+* **pricing:** disabling one item no longer disabled every items ([dd1769b](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/dd1769b)), closes [#1761](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/issues/1761)
+* **search:** fixed an issue with "add selection to list" sometimes not working ([c95147e](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/c95147e))
+* **simulator:** Tricks of the Trade no longer regenerate 20CP on normal state in linear mode ([a9c4c1a](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/a9c4c1a))
+
+
+### Features
+
+* **db:** removed festival npcs when possible and duplicate names ([c88b4fe](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/c88b4fe))
+* **layout:** new layout type: npc breakdown, enabled by default on default layout's vendor panel ([89c3ebe](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/89c3ebe))
+* **list:** new list color: light blue ([5becc8e](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/5becc8e))
+* **log-tracker:** better display and filtering for log pages ([e98d20d](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/e98d20d))
+* you can now disable auto patch notes on update, and open them from sidebar ([f033b8b](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/f033b8b))
+
+
+
 <a name="7.6.13"></a>
 ## [7.6.13](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/compare/v7.6.12...v7.6.13) (2020-12-23)
 

--- a/apps/client/src/app/model/common/npc-breakdown.ts
+++ b/apps/client/src/app/model/common/npc-breakdown.ts
@@ -62,11 +62,15 @@ export class NpcBreakdown {
     const tradeSources = getItemSource(row, DataType.TRADE_SOURCES);
     const bestNpc = [].concat.apply([], tradeSources.map(ts => ts.npcs)).sort((a, b) => {
       return this.getRowScore(b.id) - this.getRowScore(a.id);
-    });
+    })[0];
     this.addRow(bestNpc.id, row);
   }
 
   private getRowScore(npcId: number): number {
+    // Hardcoded fix for Anna, has a wrong map for some reason.
+    if (npcId === 1033785) {
+      return 0;
+    }
     const sameNpc = this._rows.find(r => r.npcId === npcId);
     if (sameNpc) {
       return 10 + sameNpc.items.length;

--- a/apps/client/src/app/modules/list/list-details-panel/list-details-panel.component.html
+++ b/apps/client/src/app/modules/list/list-details-panel/list-details-panel.component.html
@@ -63,7 +63,7 @@
                 <ng-template #npcTitle>
                   <div fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
                     <span class="zone-title">{{getNpc(row.npcId) | i18n}}</span>,&nbsp;
-                    <app-map-position [hideCoords]="true" [mapId]="row.position.map" [showZoneName]="true" flex="row" [zoneId]="row.position.zoneid" [marker]="row.position"></app-map-position>
+                    <app-map-position [hideCoords]="true" *ngIf="row.position" [mapId]="row.position?.map" [showZoneName]="true" flex="row" [zoneId]="row.position?.zoneid" [marker]="row.position"></app-map-position>
                   </div>
                 </ng-template>
                 <nz-divider [nzText]="npcTitle" nzOrientation="left"></nz-divider>

--- a/apps/client/src/environments/extracts-hash.ts
+++ b/apps/client/src/environments/extracts-hash.ts
@@ -1,1 +1,1 @@
-export const extractsHash = `6d944f29378e39d9b5e27f60311034005f5e9888`;
+export const extractsHash = `9fa835c9885debefc0d333acc20448aa1bb3a3a6`;

--- a/apps/client/src/environments/patch-notes.ts
+++ b/apps/client/src/environments/patch-notes.ts
@@ -3,6 +3,7 @@ export const patchNotes = `### Bug Fixes
 * **db:** fixed coords for a lot of monsters and nodes.
 * **desktop:** fixed crafting replay not recording and various machina issues.
 * **inventory-optimizer:** hovering sidebar elements no longer makes the app slow.
+* **layout:** hotfix for new npc breakdown system.
 * **log-tracker:** fixed small layout issue with some resolutions.
 * **pricing:** disabling one item no longer disabled every items.
 * **search:** fixed an issue with "add selection to list" sometimes not working.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Collaborative crafting made easy",
   "homepage": "https://ffxivteamcraft.com",
   "author": "FFXIV Teamcraft",
-  "version": "7.6.13",
+  "version": "7.6.14",
   "license": "MIT",
   "main": "desktop/main.js",
   "build": {


### PR DESCRIPTION
### Bug Fixes

* **db:** fixed coords for a lot of monsters and nodes.
* **desktop:** fixed crafting replay not recording and various machina issues.
* **inventory-optimizer:** hovering sidebar elements no longer makes the app slow.
* **layout:** hotfix for new npc breakdown system.
* **log-tracker:** fixed small layout issue with some resolutions.
* **pricing:** disabling one item no longer disabled every items.
* **search:** fixed an issue with "add selection to list" sometimes not working.
* **simulator:** Tricks of the Trade no longer regenerate 20CP on normal state in linear mode.


### Features

* **db:** removed festival npcs when possible and duplicate names.
* **layout:** new layout type: npc breakdown, enabled by default on default layout's vendor panel.
* **list:** new list color: light blue.
* **log-tracker:** better display and filtering for log pages.
* you can now disable auto patch notes on update, and open them from sidebar.