### PR TITLE
fix(ux): fix empty tooltip for alarm button

### DIFF
--- a/apps/client/src/app/modules/list/item/alarm-button/alarm-button.component.html
+++ b/apps/client/src/app/modules/list/item/alarm-button/alarm-button.component.html
@@ -5,8 +5,8 @@
           nz-tooltip
           [nzTooltipTitle]="tooltip">
     <ng-template #tooltip>
-      <span *ngIf="display.itemId">{{display.alarm.aetheryte?.nameid | placeName | i18n}} - {{display.alarm.zoneId | placeName | i18n}}</span>
-      <span *ngIf="!alarm.itemId">{{display.alarm.name}}</span>
+      <span *ngIf="display.alarm.itemId">{{display.alarm.aetheryte?.nameid | placeName | i18n}} - {{display.alarm.zoneId | placeName | i18n}}</span>
+      <span *ngIf="!display.alarm.itemId">{{display.alarm.name}}</span>
       <span *ngIf="display.alarm.fishEyes">{{'GATHERING_LOCATIONS.Fish_eyes' | translate}}</span>
     </ng-template>
     <i *ngIf="!display.registered" nz-icon nzType="bell"></i>


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/2197479/112730251-8163b500-8f6b-11eb-8aa4-b56551c2e0ef.png)

after
![image](https://user-images.githubusercontent.com/2197479/112730259-8cb6e080-8f6b-11eb-9680-64cdc44e0450.png)
