### PR TITLE
fix(simulator): Prevent tooltip leak

### DIFF
--- a/apps/client/src/app/modules/tooltip/xivapi-action-tooltip/xivapi-action-tooltip.directive.ts
+++ b/apps/client/src/app/modules/tooltip/xivapi-action-tooltip/xivapi-action-tooltip.directive.ts
@@ -37,6 +37,12 @@ export class XivapiActionTooltipDirective implements OnDestroy {
   private _overlayRef?: OverlayRef;
   /** Create a new tooltip with the given HTML, and inject it in the overlay layout. */
   private _createTooltip = (action: any) => {
+    // Remove an existing tooltip if needed.
+    // It can be present due to a missing mouseleave event during drag and drop.
+    if (this._overlayRef) {
+      this._overlayRef.dispose();
+      delete this._overlayRef;
+    }
     // Position the tooltip at the top right of the anchor.
     const positionStrategy = this._overlay
       .position()


### PR DESCRIPTION
Currently, drag and drop can cause the mouseleave event to be missing if the action element moves. This leaks the tooltip overlay element when mousing over the action again. Prevent this by checking for an existing OverlayRef when creating a tooltip.