### PR TITLE
8.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="8.1.12"></a>
+## [8.1.12](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/compare/v8.1.11...v8.1.12) (2021-04-28)
+
+
+### Bug Fixes
+
+* **fishing-overlay:** fixed chum status tracking ([c861594](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/c861594))
+* **fishing-spot:** uniform sorting of tug type data table ([5f733d5](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/5f733d5))
+* **inventory:** remove remnants of unknown inventories when character is set ([126b473](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/126b473))
+* **log-tracker:** fixed position maps not showing properly inside "see on map" popup ([e38be27](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/e38be27))
+* **simulator:** failed combo actions are no longer being considered as combo enablers ([5c46382](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/5c46382))
+* **simulator:** fixed specialist stats toggle sometimes not updating stats ([5de7a20](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/5de7a20))
+* **voyage-tracker:** fix import ([789623e](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/789623e))
+
+
+### Features
+
+* **inventory:** character inventories sharing the same name now include server name ([6c3768f](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/6c3768f))
+* **log-tracker:** you can now import FSH progress from CarbunclePlushy ([bc6639b](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/bc6639b))
+
+
+
 <a name="8.1.11"></a>
 ## [8.1.11](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/compare/v8.1.10...v8.1.11) (2021-04-27)
 

--- a/apps/client/src/app/core/electron/packet-capture-tracker.service.ts
+++ b/apps/client/src/app/core/electron/packet-capture-tracker.service.ts
@@ -117,9 +117,6 @@ export class PacketCaptureTrackerService {
 
     this.ipc.packets$.pipe(
       ofMessageType('effectResult'),
-      filter(message => {
-        return message.header.sourceActor === message.header.targetActor;
-      }),
       toIpcData()
     ).subscribe(packet => {
       for (let i = 0; i < packet.entryCount; i++) {
@@ -127,6 +124,18 @@ export class PacketCaptureTrackerService {
           this.eorzeaFacade.addStatus(packet.statusEntries[i].id);
         }
       }
+    });
+
+    this.ipc.packets$.pipe(
+      ofMessageType('statusEffectList')
+    ).subscribe(message => {
+      this.eorzeaFacade.resetStatuses();
+      const packet = message.parsedIpcData;
+      packet.effects.forEach(effect => {
+        if (effect.sourceActorId === message.header.sourceActor) {
+          this.eorzeaFacade.addStatus(effect.effectId);
+        }
+      });
     });
 
     this.ipc.packets$.pipe(

--- a/apps/client/src/app/modules/inventory/inventory.service.ts
+++ b/apps/client/src/app/modules/inventory/inventory.service.ts
@@ -282,7 +282,13 @@ export class InventoryService {
       return containerName;
     } else {
       const entry = this.characterEntries.find(e => e.contentId === item.contentId);
-      return `${containerName} (${entry?.character.Character.Name || this.translate.instant('COMMON.Unknown')})`;
+      const otherCharactersWithSameName = this.characterEntries.filter(e => e.character.Character.Name === entry?.character.Character.Name);
+      let characterName = entry?.character.Character.Name;
+      if (otherCharactersWithSameName.length > 1) {
+        // If we have multiple characters sharing the same name, just add server name to the character name
+        characterName = `${entry?.character.Character.Name} (${entry?.character.Character.Server})`;
+      }
+      return `${containerName} (${characterName || this.translate.instant('COMMON.Unknown')})`;
     }
   }
 

--- a/apps/client/src/app/modules/inventory/inventory.service.ts
+++ b/apps/client/src/app/modules/inventory/inventory.service.ts
@@ -148,6 +148,8 @@ export class InventoryService {
             switch (action.type) {
               case 'SetContentId':
                 state.inventory.contentId = action.contentId;
+                delete state.inventory.items['null'];
+                delete state.inventory.items['undefined'];
                 return { ...state, inventory: state.inventory };
               case 'Reset':
                 const reset = new UserInventory();

--- a/apps/client/src/app/pages/db/fishing-spot/fishing-spot-tug-datagrid/fishing-spot-tug-datagrid.component.ts
+++ b/apps/client/src/app/pages/db/fishing-spot/fishing-spot-tug-datagrid/fishing-spot-tug-datagrid.component.ts
@@ -22,7 +22,7 @@ export class FishingSpotTugDatagridComponent {
       const fishes: number[] = spots.find((spot) => spot.id === spotId)?.fishes ?? [];
       return {
         ...res.data,
-        colDefs: res.data.colDefs.sort((a, b) => (b.colId === 2 ? 1 : b.colId === 1 ? -1 : 0)),
+        colDefs: res.data.colDefs.sort((a, b) => a.colId - b.colId),
         data: res.data.data.sort((a, b) => fishes.indexOf(a.rowId) - fishes.indexOf(b.rowId)),
       };
     })

--- a/apps/client/src/app/pages/log-tracker/fishing-log-tracker/fishing-log-tracker.component.html
+++ b/apps/client/src/app/pages/log-tracker/fishing-log-tracker/fishing-log-tracker.component.html
@@ -5,8 +5,13 @@
              nzSize="small">
     <ng-template #extraTemplate>
       <div class="dol-path-buttons" fxLayout="row" fxLayoutGap="10px">
+        <div>
+          <button nz-button nzType="primary" (click)="importFromCP()">
+            {{'LOG_TRACKER.Import_from_carbuncleplushy' | translate}}
+          </button>
+        </div>
         <div fxLayout="row" fxLayoutAlign="flex-end center" fxLayoutGap="5px">
-          <nz-switch  [(ngModel)]="hideCompleted" (ngModelChange)="settings.hideCompletedLogEntries = $event"></nz-switch>
+          <nz-switch [(ngModel)]="hideCompleted" (ngModelChange)="settings.hideCompletedLogEntries = $event"></nz-switch>
           <div>{{'LOG_TRACKER.Hide_completed_items' | translate}}</div>
         </div>
       </div>

--- a/apps/client/src/app/pages/log-tracker/log-tracker.module.ts
+++ b/apps/client/src/app/pages/log-tracker/log-tracker.module.ts
@@ -18,6 +18,7 @@ import { TooltipModule } from '../../modules/tooltip/tooltip.module';
 import { FishingLogTrackerComponent } from './fishing-log-tracker/fishing-log-tracker.component';
 import { FullpageMessageModule } from '../../modules/fullpage-message/fullpage-message.module';
 import { AntdSharedModule } from '../../core/antd-shared.module';
+import { TextQuestionPopupModule } from '../../modules/text-question-popup/text-question-popup.module';
 
 const routes: Routes = [
   {
@@ -50,7 +51,8 @@ const routes: Routes = [
     TooltipModule,
     FullpageMessageModule,
 
-    AntdSharedModule
+    AntdSharedModule,
+    TextQuestionPopupModule
   ]
 })
 export class LogTrackerModule {

--- a/apps/client/src/app/pages/log-tracker/log-tracker/log-tracker.component.html
+++ b/apps/client/src/app/pages/log-tracker/log-tracker/log-tracker.component.html
@@ -166,7 +166,7 @@
                                        fxLayoutAlign="flex-start center">
                                     <div fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="5px">
                                       <div>
-                                        <app-map-position [mapId]="node.gatheringNode.mapId"
+                                        <app-map-position [mapId]="node.gatheringNode.map"
                                                           *ngIf="node.gatheringNode.x !== undefined"
                                                           [marker]="{x: node.gatheringNode.x, y: node.gatheringNode.y, iconType: 'img', iconImg: node.gatheringNode.type | nodeTypeIcon: node.gatheringNode.limited}"
                                                           [showZoneName]="true"

--- a/apps/client/src/app/pages/simulator/components/simulator/simulator.component.html
+++ b/apps/client/src/app/pages/simulator/components/simulator/simulator.component.html
@@ -238,10 +238,9 @@
                   </nz-form-item>
                   <nz-form-item>
                     <nz-form-control>
-                      <label (click)="toggleSpecialist()" formControlName="specialist"
+                      <label formControlName="specialist"
                              id="specialist"
-                             nz-checkbox>{{'SIMULATOR.CONFIGURATION.Specialist'
-                        | translate}}</label>
+                             nz-checkbox>{{'SIMULATOR.CONFIGURATION.Specialist' | translate}}</label>
                     </nz-form-control>
                   </nz-form-item>
                 </div>

--- a/apps/client/src/app/pages/simulator/components/simulator/simulator.component.ts
+++ b/apps/client/src/app/pages/simulator/components/simulator/simulator.component.ts
@@ -1,7 +1,20 @@
 import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { BehaviorSubject, combineLatest, merge, Observable, ReplaySubject, Subject } from 'rxjs';
 import { Craft } from '../../../../model/garland-tools/craft';
-import { debounceTime, distinctUntilChanged, filter, first, map, pairwise, shareReplay, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  distinctUntilKeyChanged,
+  filter,
+  first,
+  map,
+  pairwise,
+  shareReplay,
+  startWith,
+  switchMap,
+  takeUntil,
+  tap
+} from 'rxjs/operators';
 import { HtmlToolsService } from '../../../../core/tools/html-tools.service';
 import { AuthFacade } from '../../../../+state/auth.facade';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
@@ -271,6 +284,13 @@ export class SimulatorComponent implements OnInit, OnDestroy {
       level: [0, Validators.required],
       specialist: [false]
     });
+
+    this.statsForm.valueChanges.pipe(
+      distinctUntilKeyChanged('specialist'),
+      takeUntil(this.onDestroy$)
+    ).subscribe(() => {
+      this.toggleSpecialist();
+    })
 
     this.foods = consumablesService.fromLazyData(this.lazyData.data.foods)
       .sort(this.consumablesSortFn);

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -1306,6 +1306,9 @@
     "Hide_completed_items": "Hide completed items",
     "MIN_optimized_path": "Optimized path for all MIN nodes",
     "BTN_optimized_path": "Optimized path for all BTN nodes",
+    "Import_from_carbuncleplushy": "Import progress from CarbunclePlushy",
+    "Import_from_carbuncleplushy_failed": "Import failed, wrong JSON was provided, make sure to use the full settings export",
+    "Import_from_carbuncleplushy_success": "Fishing log tracker updated successfully",
     "PAGE": {
       "Master_recipes": "Master recipes ({{number}})",
       "Housing_items": "Housing({{number}})",

--- a/apps/client/src/environments/patch-notes.ts
+++ b/apps/client/src/environments/patch-notes.ts
@@ -1,21 +1,15 @@
 export const patchNotes = `### Bug Fixes
 
-* **Alarms:** fix nodes to not group if on same zone.
-* **Alarms:** use strict match instead normal match.
-* **collectibles:** fixed collectibles results not loading when a level is 0.
-* **desktop:** prevent any inventory tracking action when contentId is unknown.
-* **lists:** you can now load archived lists with direct links.
-* **marketboard:** fixed broken sort headers in marketboard popup.
-* **simulator:** Prevent tooltip leak.
-* **universalis:** fixed marketboard data publisher.
-* **voyage-tracker:** clarification in the import popup process.
-* **voyage-tracker:** remove diadem sector from the discovered sectors.
-* **voyage-tracker:** support for KR/CN..
+* **fishing-overlay:** fixed chum status tracking.
+* **fishing-spot:** uniform sorting of tug type data table.
+* **inventory:** remove remnants of unknown inventories when character is set.
+* **log-tracker:** fixed position maps not showing properly inside "see on map" popup.
+* **simulator:** failed combo actions are no longer being considered as combo enablers.
+* **simulator:** fixed specialist stats toggle sometimes not updating stats.
+* **voyage-tracker:** fix import.
 
 
 ### Features
 
-* **character-linking:** added character server to the character avatar tooltip.
-* **currency-spending:** added fête token to the possible currencies.
-* **db:** better details for gardening, including cross breeds.
-* **desktop:** better character detection with dalamud character sync plugin.`;
+* **inventory:** character inventories sharing the same name now include server name.
+* **log-tracker:** you can now import FSH progress from CarbunclePlushy.`;

--- a/apps/client/src/environments/patch-notes.ts
+++ b/apps/client/src/environments/patch-notes.ts
@@ -1,14 +1,21 @@
 export const patchNotes = `### Bug Fixes
 
-* **alarms:** fixed weather alarm timers going derp once spawned.
-* **desktop:** better character detection for Universalis.
-* **desktop:** fixed retainer tracking with long CN/KO names.
-* **treasure-finder:** fixed missing treasure maps.
-* **voyage-tracker:** fixed maximum submarine rank.
+* **Alarms:** fix nodes to not group if on same zone.
+* **Alarms:** use strict match instead normal match.
+* **collectibles:** fixed collectibles results not loading when a level is 0.
+* **desktop:** prevent any inventory tracking action when contentId is unknown.
+* **lists:** you can now load archived lists with direct links.
+* **marketboard:** fixed broken sort headers in marketboard popup.
+* **simulator:** Prevent tooltip leak.
+* **universalis:** fixed marketboard data publisher.
+* **voyage-tracker:** clarification in the import popup process.
+* **voyage-tracker:** remove diadem sector from the discovered sectors.
+* **voyage-tracker:** support for KR/CN..
 
 
 ### Features
 
-* **desktop:** new setting to show other characters inventories in inventory page.
-* **desktop:** no more character id reset on logout with only one linked character.
-* **simulator:** added macro duration below each macro fragment.`;
+* **character-linking:** added character server to the character avatar tooltip.
+* **currency-spending:** added fête token to the possible currencies.
+* **db:** better details for gardening, including cross breeds.
+* **desktop:** better character detection with dalamud character sync plugin.`;

--- a/apps/electron/src/pcap/packet-capture.ts
+++ b/apps/electron/src/pcap/packet-capture.ts
@@ -27,6 +27,7 @@ export class PacketCapture {
     'eventPlay8',
     'eventStart',
     'freeCompanyInfo',
+    'freeCompanyDialog',
     'initZone',
     'inventoryModifyHandler',
     'inventoryTransaction',

--- a/apps/electron/src/pcap/packet-capture.ts
+++ b/apps/electron/src/pcap/packet-capture.ts
@@ -54,7 +54,8 @@ export class PacketCapture {
     'updateInventorySlot',
     'updatePositionHandler',
     'updatePositionInstance',
-    'weatherChange'
+    'weatherChange',
+    'statusEffectList'
   ];
 
   private static readonly PACKETS_FROM_OTHERS = [
@@ -62,7 +63,6 @@ export class PacketCapture {
     'actorControl',
     'updateClassInfo',
     'actorControlSelf',
-    'effectResult',
     'eventPlay',
     'eventStart',
     'eventFinish',

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Collaborative crafting made easy",
   "homepage": "https://ffxivteamcraft.com",
   "author": "FFXIV Teamcraft",
-  "version": "8.1.11",
+  "version": "8.1.12",
   "license": "MIT",
   "main": "dist/apps/electron/src/main.js",
   "build": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "@angular/platform-browser-dynamic": "^11.0.2",
     "@angular/router": "^11.0.2",
     "@ffxiv-teamcraft/crafting-solver": "^1.3.2",
-    "@ffxiv-teamcraft/simulator": "^2.10.7",
+    "@ffxiv-teamcraft/simulator": "^2.10.8",
     "@ffxiv-teamcraft/simulator-cn": "npm:@ffxiv-teamcraft/simulator@2.9.2",
     "@ffxiv-teamcraft/simulator-kr": "npm:@ffxiv-teamcraft/simulator@2.7.1",
     "@firebase/auth-types": "^0.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,10 +2401,10 @@
   dependencies:
     "@kaiu/serializer" "^1.4.0"
 
-"@ffxiv-teamcraft/simulator@^2.10.7":
-  version "2.10.7"
-  resolved "https://registry.yarnpkg.com/@ffxiv-teamcraft/simulator/-/simulator-2.10.7.tgz#407c3f6ead59d34fc88c5b1809c9c6caea85269b"
-  integrity sha512-0f1umCI5Ra5mPx+PyCPgM2XuT3fXfbRwMnfnYTgQ3BKa+/OLl4jfu+u3Rhotdp4RN4aA9lnDbqGfeQmS+LEIzg==
+"@ffxiv-teamcraft/simulator@^2.10.8":
+  version "2.10.8"
+  resolved "https://registry.yarnpkg.com/@ffxiv-teamcraft/simulator/-/simulator-2.10.8.tgz#76c753bf07f8f9bb8f8ba9af619a9b17682328a2"
+  integrity sha512-Po9tmmAHvh9BsVEbBTeqQAucvvUUa6d2hvt0zcabZkN4euVnsyFwJ951b9B7OB1qcsqDaYHxDhy4CtbQ9ya6QQ==
   dependencies:
     "@kaiu/serializer" "^1.4.0"
 


### PR DESCRIPTION
### Bug Fixes

* **fishing-overlay:** fixed chum status tracking.
* **fishing-spot:** uniform sorting of tug type data table.
* **inventory:** remove remnants of unknown inventories when character is set.
* **log-tracker:** fixed position maps not showing properly inside "see on map" popup.
* **simulator:** failed combo actions are no longer being considered as combo enablers.
* **simulator:** fixed specialist stats toggle sometimes not updating stats.
* **voyage-tracker:** fix import.


### Features

* **inventory:** character inventories sharing the same name now include server name.
* **log-tracker:** you can now import FSH progress from CarbunclePlushy.