### PR TITLE
Correction of a XML Error

### DIFF
--- a/apps/client/src/assets/opensearch.xml
+++ b/apps/client/src/assets/opensearch.xml
@@ -4,6 +4,8 @@
   <ShortName>FFXIV Teamcraft</ShortName>
   <Description>Search on FFXIV Teamcraft</Description>
   <InputEncoding>UTF-8</InputEncoding>
-  <Url method="get" type="text/html"
-       template="https://ffxivteamcraft.com/search?query={searchTerms}&type=Any"/>
+  <Url method="get" type="text/html" template="https://ffxivteamcraft.com/search">
+    <Param name="query" value="{searchTerms}"/>
+    <Param name="type" value="Any"/>
+  </Url>
 </OpenSearchDescription>


### PR DESCRIPTION
The XML had an error when adding to Firefox. 

![grafik](https://user-images.githubusercontent.com/83910432/117575188-0a304d80-b0e1-11eb-8a5f-2833e995fb1c.png)

With this change the search engine can be added. Tested on Firefox 88.0.1

![grafik](https://user-images.githubusercontent.com/83910432/117575203-1d431d80-b0e1-11eb-9acd-9a3e45c8e2a1.png)
