### PR TITLE
fix(pcap): force powershell to stop

### DIFF
--- a/apps/electron/src/pcap/packet-capture.ts
+++ b/apps/electron/src/pcap/packet-capture.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { exec, execSync } from 'child_process';
 import { MainWindow } from '../window/main-window';
 import { Store } from '../store';
 import { join, resolve } from 'path';
@@ -84,13 +84,15 @@ export class PacketCapture {
   }
 
   start(): void {
-    exec('Get-Service -Name Npcap', { 'shell': 'powershell.exe' }, (err) => {
-      if (err) {
-        this.mainWindow.win.webContents.send('install-npcap-prompt', true);
-      } else {
-        this.startMachina();
-      }
-    });
+    log.info(`Starting PacketCapture with options: ${JSON.stringify(this.options)}`);
+    try {
+      const cmdOutput = execSync('Get-Service -Name Npcap', {'shell': 'powershell.exe', 'timeout': 5000, 'stdio': ['ignore', 'pipe', 'ignore']});
+      log.debug('The Npcap service was detected, starting Machina');
+      this.startMachina();
+    } catch (err) {
+      log.error(`Error and/or possible timeout while detecting the Npcap windows service: ${err}`);
+      this.mainWindow.win.webContents.send('install-npcap-prompt', true);
+    };
   }
 
   stop(): void {


### PR DESCRIPTION
Move the powershell exec to a synchronous one with a timeout.

Resolve issue where the exec call never stop and never trigger the callback.

As the call to powershell to check the pcap service may never finish, the callback to start Machina is also never triggered.
To fix that, the shell call is now synchronous, has a timeout and stdio parameters to make more robust.