### PR TITLE
fix(lists): item craft ready blue highlight fix

### DIFF
--- a/apps/client/src/app/modules/list/model/list.ts
+++ b/apps/client/src/app/modules/list/model/list.ts
@@ -433,7 +433,6 @@ export class List extends DataWithPermissions {
     // If it's not a craft, break recursion
     if (getItemSource(item, DataType.CRAFTED_BY).length === 0 || item.requires === undefined) {
       // Simply return the amount of the item being equal to the amount needed.
-      return item.done >= amount;
       return item.done - item.used >= amount; //subtracting item.used here probably does something???
     }
     // If we already have the precraft done, don't go further into the requirements.

--- a/apps/client/src/app/modules/list/model/list.ts
+++ b/apps/client/src/app/modules/list/model/list.ts
@@ -332,6 +332,7 @@ export class List extends DataWithPermissions {
     if (item.done < 0) {
       item.done = 0;
     }
+    this.updateAllStatuses(item.id); //propagate changes
     const newDone = item.amount_needed - MathTools.absoluteCeil((item.amount - item.done) / item.yield);
     amount = newDone - previousDone;
     if (item.requires !== undefined && newDone !== previousDone) {
@@ -433,9 +434,10 @@ export class List extends DataWithPermissions {
     if (getItemSource(item, DataType.CRAFTED_BY).length === 0 || item.requires === undefined) {
       // Simply return the amount of the item being equal to the amount needed.
       return item.done >= amount;
+      return item.done - item.used >= amount; //subtracting item.used here probably does something???
     }
     // If we already have the precraft done, don't go further into the requirements.
-    if (item.done >= amount || item.canBeCrafted) {
+    if (item.done - item.used >= amount) {  //subtracting item.used here prevents the dotted blue line from appearing around final items which think the materials for a pre-craft exist. 
       return true;
     }
     // Don't mind crystals


### PR DESCRIPTION
#1721 

This seems to follow the requested (and, to me, logical) behavior in the bug report. I have only tested with b-sen's example and a small example of my own, so it likely breaks something elsewhere. 

If nothing is broken and this is an acceptable fix, I'd still like to polish it up some more - I'm sure we could be more specific about which items to update, etc. Just wanted to see if I'm headed in the right direction, I guess!

![image](https://user-images.githubusercontent.com/89751433/131584154-86c6f255-c8ac-4a51-bc20-734dfd2d7750.png)
