### PR TITLE
feat(fishing): add fish, bait icons to fishing-spot-bite-times box plot

### DIFF
--- a/apps/client/src/app/pages/db/fishing-spot/fishing-spot-bite-times/fishing-spot-bite-times.component.html
+++ b/apps/client/src/app/pages/db/fishing-spot/fishing-spot-bite-times/fishing-spot-bite-times.component.html
@@ -2,7 +2,16 @@
   <ng-template #baitSelector>
     <nz-select *ngIf="baitIds$ | async as baits" [ngModel]="baitFilter$ | async" (ngModelChange)="setBaitId($event)" nzShowSearch class="bait-selector">
       <nz-option [nzValue]="-1" [nzLabel]="'DB.FISH.All_baits' | translate"></nz-option>
-      <nz-option *ngFor="let bait of baits" [nzValue]="bait" [nzLabel]="bait | itemName | i18n"></nz-option>
+      <nz-option *ngFor="let bait of baits" [nzLabel]="bait | itemName | i18n"
+                 [nzValue]="bait"
+                 nzCustomContent>
+        <div [title]="bait | itemName | i18n" fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
+          <img [src]="bait | lazyIcon" alt="" class="bait-icon">
+          <div>
+            {{bait | itemName | i18n}}
+          </div>
+        </div>
+      </nz-option>
     </nz-select>
   </ng-template>
   <div>

--- a/apps/client/src/app/pages/db/fishing-spot/fishing-spot-bite-times/fishing-spot-bite-times.component.less
+++ b/apps/client/src/app/pages/db/fishing-spot/fishing-spot-bite-times/fishing-spot-bite-times.component.less
@@ -8,6 +8,10 @@
   min-width: 200px;
 }
 
+.bait-icon {
+  width: 24px;
+}
+
 .legend-box {
   height: 10px;
   width: 30px;

--- a/apps/client/src/app/pages/db/fishing-spot/fishing-spot-bite-times/fishing-spot-bite-times.component.ts
+++ b/apps/client/src/app/pages/db/fishing-spot/fishing-spot-bite-times/fishing-spot-bite-times.component.ts
@@ -5,8 +5,26 @@ import { SettingsService } from 'apps/client/src/app/modules/settings/settings.s
 import { combineLatest, Observable, of, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, map, shareReplay, startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { FishContextService } from '../../service/fish-context.service';
+import { LazyDataService } from '../../../../core/data/lazy-data.service';
 import { TranslateService } from '@ngx-translate/core';
 import { ChartOptions } from 'chart.js';
+import { Chart } from 'chart.js';
+
+const fishImageUrls = []
+
+Chart.pluginService.register({
+  afterDraw: chart => {      
+    var ctx = chart.chart.ctx; 
+    var xAxis = chart.scales['x-axis-0'];
+    var yAxis = chart.scales['y-axis-0'];
+    yAxis.ticks.forEach((value, index) => {  
+      var y = yAxis.getPixelForTick(index);      
+      var image = new Image();
+      image.src = fishImageUrls[index],
+      ctx.drawImage(image, xAxis.left - 33, y - 16, 32, 32);
+    });      
+  }
+});
 
 interface FishingSpotChartData {
   id: number;
@@ -87,7 +105,8 @@ export class FishingSpotBiteTimesComponent implements OnInit, OnDestroy {
             datasets: [{
               borderWidth: 1,
               itemRadius: 0,
-              data: sortedNames.map(el => {
+              data: sortedNames.map((el, index) => {
+                fishImageUrls[index] = 'https://xivapi.com' + this.lazyData.data.itemIcons[el.id]
                 return Object.entries(res.data.byFish[el.id].byTime)
                   .map(([time, occurences]) => {
                     return new Array(occurences).fill(+time);
@@ -137,7 +156,8 @@ export class FishingSpotBiteTimesComponent implements OnInit, OnDestroy {
       }],
       yAxes: [{
         ticks: {
-          fontColor: this.fontColor
+          fontColor: this.fontColor,
+          padding: 30
         },
         gridLines: {
           color: this.gridColor
@@ -175,7 +195,8 @@ export class FishingSpotBiteTimesComponent implements OnInit, OnDestroy {
     private readonly i18n: I18nToolsService,
     public readonly settings: SettingsService,
     public readonly fishCtx: FishContextService,
-    private readonly translate: TranslateService
+    private readonly translate: TranslateService,
+    private lazyData: LazyDataService
   ) {
   }
 


### PR DESCRIPTION
First off, huge thank you to all the contributors and maintainers of ffxiv-teamcraft, it has really evolved into an amazing and broadly useful tool 👏 

I am a Fisher main and play FFXIV in my second language, Japanese.  While the "bite times" chart is very useful as-is, for a player like me I thought it would be handy to have icons for both the fish and the baits, improving quick readability when checking and double checking my bait in-game and what my target fish is, etc.  

I am not an expert in any of the frameworks in use here, but with some very helpful hints from the Discord was able to implement the solution I found [here](https://stackoverflow.com/questions/30247579/how-to-add-an-images-as-labels-to-canvas-charts-using-chart-js).

Here is a screenshot from localhost:

![image](https://user-images.githubusercontent.com/6663484/131870844-a83548af-39aa-4752-af30-9c65800309fa.png)

Thank you for your consideration to incorporate this feature.
