### PR TITLE
fix(log-tracker): use correct hookset string for tooltip

### DIFF
--- a/apps/client/src/app/pages/log-tracker/fishing-log-tracker/fishing-log-tracker.component.html
+++ b/apps/client/src/app/pages/log-tracker/fishing-log-tracker/fishing-log-tracker.component.html
@@ -130,7 +130,7 @@
                                    class="gig-icon"
                                    nz-tooltip src="./assets/icons/gig/{{entry.gatheringNode.gig}}.png">
                               <img *ngIf="entry.gatheringNode.hookset"
-                                   [nzTooltipTitle]="(entry.gatheringNode.hookset === 'Precision Hookset'? 4179 : 4103) | actionName | i18n"
+                                   [nzTooltipTitle]="(entry.gatheringNode.hookset === 'precision'? 4179 : 4103) | actionName | i18n"
                                    class="gig-icon"
                                    nz-tooltip
                                    src="./assets/icons/hookset/{{entry.gatheringNode.hookset}}.png">


### PR DESCRIPTION
The GatheringNode model calls the hooksets `precision` and `powerful` but the template is checking for `Precision Hookset` so the tooltip ends up always displaying Powerful Hookset. I saw there's an enum for normal/precision/powerful so ideally we should have the model use that with action IDs as a value or some sort of simple function to get an ID, but this fix is a quick and dirty one that matches the model.