### PR TITLE
8.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="8.6.0"></a>
+# [8.6.0](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/compare/v8.5.9...v8.6.0) (2021-10-02)
+
+
+### Bug Fixes
+
+* **db:** fixed a bug with fishing spot bite times chart and baits with few data points ([6c564d6](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/6c564d6))
+
+
+### Features
+
+* **data:** update for cn patch-5.55 ([96b68ff](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/96b68ff))
+* **db:** added # of records for hookset and tug display in fish details ([d43a0f7](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/d43a0f7))
+* **db:** added new misses toggle for bait datagrid in fishing spot pages ([0ed78f0](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/0ed78f0))
+* **db:** new data report system to add missing sources by hand ([84038f9](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/84038f9))
+* **retainers:** you can now track items sold on MB ([203c804](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/203c804))
+
+
+
 <a name="8.5.9"></a>
 ## [8.5.9](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/compare/v8.5.8...v8.5.9) (2021-09-22)
 

--- a/apps/client/src/environments/extracts-hash.ts
+++ b/apps/client/src/environments/extracts-hash.ts
@@ -1,1 +1,1 @@
-export const extractsHash = `dc744cf4486ed00362024e8ea74d016eb86aef30`;
+export const extractsHash = `78d60ee219fdf0cbc161079bd8b22276cd0c52c1`;

--- a/apps/client/src/environments/patch-notes.ts
+++ b/apps/client/src/environments/patch-notes.ts
@@ -1,4 +1,12 @@
 export const patchNotes = `### Bug Fixes
 
-* **alarms:** fixed weather + time alarms not being accurate with twice the same weather in a row.
-* **marketboard:** fixed server MB data fetching not working at all.`;
+* **db:** fixed a bug with fishing spot bite times chart and baits with few data points.
+
+
+### Features
+
+* **data:** update for cn patch-5.55.
+* **db:** added # of records for hookset and tug display in fish details.
+* **db:** added new misses toggle for bait datagrid in fishing spot pages.
+* **db:** new data report system to add missing sources by hand.
+* **retainers:** you can now track items sold on MB.`;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Collaborative crafting made easy",
   "homepage": "https://ffxivteamcraft.com",
   "author": "FFXIV Teamcraft",
-  "version": "8.5.9",
+  "version": "8.6.0",
   "license": "MIT",
   "main": "dist/apps/electron/src/main.js",
   "build": {


### PR DESCRIPTION
### Bug Fixes

* **db:** fixed a bug with fishing spot bite times chart and baits with few data points.


### Features

* **data:** update for cn patch-5.55.
* **db:** added # of records for hookset and tug display in fish details.
* **db:** added new misses toggle for bait datagrid in fishing spot pages.
* **db:** new data report system to add missing sources by hand.
* **retainers:** you can now track items sold on MB.