### PR TITLE
Fix excessive universalis requests in marketboard popup

### DIFF
--- a/apps/client/src/app/+state/auth.facade.ts
+++ b/apps/client/src/app/+state/auth.facade.ts
@@ -238,8 +238,10 @@ export class AuthFacade {
       this.setCID(packet.contentId.toString());
     });
 
-    this.ipc.worldId$.subscribe(worldId => {
-      this.setWorld(worldId);
+    this.ipc.worldId$.pipe(
+      distinctUntilChanged()
+    ).subscribe((worldId) => {
+        this.setWorld(worldId);
     });
   }
 

--- a/apps/client/src/app/core/electron/ipc.service.ts
+++ b/apps/client/src/app/core/electron/ipc.service.ts
@@ -4,7 +4,7 @@ import { IpcRenderer, IpcRendererEvent } from 'electron';
 import { Router } from '@angular/router';
 import { Vector2 } from '../tools/vector2';
 import { BehaviorSubject, Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
-import { bufferCount, debounceTime, distinctUntilChanged, first, map, shareReplay, switchMap } from 'rxjs/operators';
+import { bufferCount, debounceTime, distinctUntilChanged, filter, first, map, shareReplay, switchMap } from 'rxjs/operators';
 import { ofMessageType } from '../rxjs/of-message-type';
 import { Store } from '@ngrx/store';
 import { NzModalService } from 'ng-zorro-antd/modal';
@@ -96,6 +96,7 @@ export class IpcService {
   public get worldId$(): Observable<number> {
     return this.packets$.pipe(
       ofMessageType('playerSpawn'),
+      filter(packet => packet.header.sourceActor === packet.header.targetActor),
       toIpcData(),
       map(packet => {
         return packet.currentWorldId;

--- a/apps/client/src/app/modules/marketboard/marketboard-popup/marketboard-popup.component.ts
+++ b/apps/client/src/app/modules/marketboard/marketboard-popup/marketboard-popup.component.ts
@@ -48,7 +48,7 @@ export class MarketboardPopupComponent implements OnInit {
   ngOnInit() {
     this.server$ = this.authFacade.mainCharacter$.pipe(
       map(character => character.Server),
-      shareReplay(1)
+      shareReplay({ bufferSize: 1, refCount: true })
     );
 
     const data$: Observable<MarketboardItem> = this.server$.pipe(
@@ -79,7 +79,7 @@ export class MarketboardPopupComponent implements OnInit {
           })
         );
       }),
-      shareReplay(1)
+      shareReplay({ bufferSize: 1, refCount: true })
     );
 
     this.prices$ = combineLatest([data$
@@ -91,7 +91,7 @@ export class MarketboardPopupComponent implements OnInit {
           this.error = true;
           return of([]);
         }),
-        shareReplay(1)
+        shareReplay({ bufferSize: 1, refCount: true })
       ),
       this.sort$
     ]).pipe(
@@ -130,7 +130,7 @@ export class MarketboardPopupComponent implements OnInit {
             };
           });
       }),
-      shareReplay(1)
+      shareReplay({ bufferSize: 1, refCount: true })
     );
 
     this.lastUpdated$ = data$.pipe(

--- a/apps/client/src/app/modules/marketboard/marketboard-popup/marketboard-popup.component.ts
+++ b/apps/client/src/app/modules/marketboard/marketboard-popup/marketboard-popup.component.ts
@@ -78,7 +78,8 @@ export class MarketboardPopupComponent implements OnInit {
             return res;
           })
         );
-      })
+      }),
+      shareReplay(1)
     );
 
     this.prices$ = combineLatest([data$


### PR DESCRIPTION
This PR fixes two things which contributed to marketboard popup, even after being closed, causing additional requests to Universalis, sometimes in great numbers.

1. Unnecessary (new value === old value) world ID updates, which caused execution of all downstream functions, including re-retrieving data from Universalis even though nothing has changed.
2. Observables in marketboard popup component surviving the destruction of the popup window itself, which caused them to request updates to marketboard data without any benefit to the user.

This PR couldn't have happened without ample help from Miu and Ay, thanks!