### PR TITLE
Update Submarine max level to 105.

### DIFF
--- a/apps/client/src/app/modules/free-company-workshops/+state/free-company-workshop.facade.ts
+++ b/apps/client/src/app/modules/free-company-workshops/+state/free-company-workshop.facade.ts
@@ -476,7 +476,7 @@ export class FreeCompanyWorkshopFacade {
     if (this.env.gameVersion < 6.2) {
       return of(95);
     }
-    return of(100);
+    return of(105);
   }
 
   @Memoized()


### PR DESCRIPTION
This only affects those regions with patch 6.3. ZH/KR are not affected by this.