### PR TITLE
feat(island-workshop): new checkbox to display item metadata in planning

### DIFF
--- a/apps/client/src/app/pages/island-workshop/island-workshop/island-workshop.component.html
+++ b/apps/client/src/app/pages/island-workshop/island-workshop/island-workshop.component.html
@@ -49,6 +49,10 @@
         <label nz-checkbox [ngModel]="excludeCropMaterials$ | async" (ngModelChange)="excludeCropMaterials$.next($event)">
           {{'ISLAND_SANCTUARY.WORKSHOP.Exclude_crop_materials' | translate}}</label>
       </div>
+      <div>
+        <label nz-checkbox [ngModel]="displayItemMetadata$ | async" (ngModelChange)="displayItemMetadata$.next($event)">
+          {{'ISLAND_SANCTUARY.WORKSHOP.Display_item_metadata' | translate}}</label>
+      </div>
     </div>
   </nz-page-header-content>
 </nz-page-header>
@@ -62,7 +66,8 @@
 <ng-container *ngIf="optimizerResult$ | async as optimizerResult">
   <app-workshop-planning *ngIf="optimizerResult.planning !== null" [planning]="optimizerResult.planning" [totalScore]="optimizerResult.score"
                          [today]="today$ | async"
-                         [weeklyReset]="previousWeeklyReset$ | async"></app-workshop-planning>
+                         [weeklyReset]="previousWeeklyReset$ | async"
+                         [displayItemMetadata]="displayItemMetadata$.value"></app-workshop-planning>
   <nz-alert *ngIf="optimizerResult.planning === null" [nzMessage]="'ISLAND_SANCTUARY.WORKSHOP.No_planning' | translate"
             [nzDescription]="'ISLAND_SANCTUARY.WORKSHOP.No_planning_explain' | translate"
             nzType="error" nzShowIcon></nz-alert>
@@ -199,4 +204,3 @@
     </nz-table>
   </ng-container>
 </ng-template>
-

--- a/apps/client/src/app/pages/island-workshop/island-workshop/island-workshop.component.html
+++ b/apps/client/src/app/pages/island-workshop/island-workshop/island-workshop.component.html
@@ -67,7 +67,7 @@
   <app-workshop-planning *ngIf="optimizerResult.planning !== null" [planning]="optimizerResult.planning" [totalScore]="optimizerResult.score"
                          [today]="today$ | async"
                          [weeklyReset]="previousWeeklyReset$ | async"
-                         [displayItemMetadata]="displayItemMetadata$.value"></app-workshop-planning>
+                         [displayItemMetadata]="displayItemMetadata$ | async"></app-workshop-planning>
   <nz-alert *ngIf="optimizerResult.planning === null" [nzMessage]="'ISLAND_SANCTUARY.WORKSHOP.No_planning' | translate"
             [nzDescription]="'ISLAND_SANCTUARY.WORKSHOP.No_planning_explain' | translate"
             nzType="error" nzShowIcon></nz-alert>

--- a/apps/client/src/app/pages/island-workshop/island-workshop/island-workshop.component.ts
+++ b/apps/client/src/app/pages/island-workshop/island-workshop/island-workshop.component.ts
@@ -146,6 +146,8 @@ export class IslandWorkshopComponent extends TeamcraftComponent {
 
   public excludeCropMaterials$ = new LocalStorageBehaviorSubject<boolean>('island-workshop:exclude_crops', false);
 
+  public displayItemMetadata$ = new LocalStorageBehaviorSubject<boolean>('island-workshop:display_item_metadata', true);
+
   public tableColumns$: Observable<ColumnItem[]> = combineLatest([
     this.translate.get('ISLAND_SANCTUARY.WORKSHOP.POPULARITY.High'),
     this.lazyData.getEntry('islandCraftworksTheme')
@@ -361,7 +363,7 @@ export class IslandWorkshopComponent extends TeamcraftComponent {
     map(([popularity, islandPopularity, objects, recipes, extracts]) => {
       const registry = Object.entries(objects)
         .filter(([id]) => {
-          return islandPopularity[popularity][id].ratio >= 120;
+          return islandPopularity[popularity] && islandPopularity[popularity][id].ratio >= 120;
         })
         .reduce((acc, [id, obj]) => {
           const recipe = recipes.find(r => r.id === `mji-craftworks-${id}`);

--- a/apps/client/src/app/pages/island-workshop/island-workshop/island-workshop.component.ts
+++ b/apps/client/src/app/pages/island-workshop/island-workshop/island-workshop.component.ts
@@ -146,7 +146,7 @@ export class IslandWorkshopComponent extends TeamcraftComponent {
 
   public excludeCropMaterials$ = new LocalStorageBehaviorSubject<boolean>('island-workshop:exclude_crops', false);
 
-  public displayItemMetadata$ = new LocalStorageBehaviorSubject<boolean>('island-workshop:display_item_metadata', true);
+  public displayItemMetadata$ = new LocalStorageBehaviorSubject<boolean>('island-workshop:display_item_metadata', false);
 
   public tableColumns$: Observable<ColumnItem[]> = combineLatest([
     this.translate.get('ISLAND_SANCTUARY.WORKSHOP.POPULARITY.High'),

--- a/apps/client/src/app/pages/island-workshop/workshop-planning/workshop-planning.component.html
+++ b/apps/client/src/app/pages/island-workshop/workshop-planning/workshop-planning.component.html
@@ -28,11 +28,26 @@
         <app-item-icon [itemId]="object.itemId" [width]="24"></app-item-icon>
         <app-i18n-name content="items" [id]="object.itemId"></app-i18n-name>
       </div>
+      <div *ngIf="displayItemMetadata" fxLayout="row" fxLayoutGap="5px" fxLayoutAlign="flex-start center">
+      <span *ngFor="let theme of object.craftworksEntry.themes; last as last"><app-i18n-name content="islandCraftworksTheme"
+                                                                                             [id]="theme"></app-i18n-name><span *ngIf="!last">,</span></span>
+      </div>
+      <!-- was trying to wrap ngIf's into a span but style was broken :( -->
+      <div *ngIf="displayItemMetadata" fxLayout="row" fxLayoutGap="5px" fxLayoutAlign="flex-start center">
+        {{object.craftworksEntry.craftingTime}}h
+      </div>
       <span *ngIf="object.alternative">
       <nz-divider [nzText]="'Or' | translate"></nz-divider>
       <div fxLayout="row" fxLayoutGap="5px" fxLayoutAlign="flex-start center">
         <app-item-icon [itemId]="object.alternative.itemId" [width]="24"></app-item-icon>
         <app-i18n-name content="items" [id]="object.alternative.itemId"></app-i18n-name>
+      </div>
+      <div *ngIf="displayItemMetadata" fxLayout="row" fxLayoutGap="5px" fxLayoutAlign="flex-start center">
+      <span *ngFor="let theme of object.craftworksEntry.themes; last as last"><app-i18n-name content="islandCraftworksTheme"
+                                                                                             [id]="theme"></app-i18n-name><span *ngIf="!last">,</span></span>
+      </div>
+      <div *ngIf="displayItemMetadata" fxLayout="row" fxLayoutGap="5px" fxLayoutAlign="flex-start center">
+        {{object.craftworksEntry.craftingTime}}h
       </div>
       </span>
     </div>

--- a/apps/client/src/app/pages/island-workshop/workshop-planning/workshop-planning.component.html
+++ b/apps/client/src/app/pages/island-workshop/workshop-planning/workshop-planning.component.html
@@ -33,7 +33,7 @@
                                                                                              [id]="theme"></app-i18n-name><span *ngIf="!last">,</span></span>
       </div>
       <!-- was trying to wrap ngIf's into a span but style was broken :( -->
-      <div *ngIf="displayItemMetadata" fxLayout="row" fxLayoutGap="5px" fxLayoutAlign="flex-start center">
+      <div *ngIf="displayItemMetadata" fxLayout="row" fxLayoutAlign="flex-start center">
         {{object.craftworksEntry.craftingTime}}h
       </div>
       <span *ngIf="object.alternative">
@@ -46,7 +46,7 @@
       <span *ngFor="let theme of object.craftworksEntry.themes; last as last"><app-i18n-name content="islandCraftworksTheme"
                                                                                              [id]="theme"></app-i18n-name><span *ngIf="!last">,</span></span>
       </div>
-      <div *ngIf="displayItemMetadata" fxLayout="row" fxLayoutGap="5px" fxLayoutAlign="flex-start center">
+      <div *ngIf="displayItemMetadata" fxLayout="row" fxLayoutAlign="flex-start center">
         {{object.craftworksEntry.craftingTime}}h
       </div>
       </span>

--- a/apps/client/src/app/pages/island-workshop/workshop-planning/workshop-planning.component.ts
+++ b/apps/client/src/app/pages/island-workshop/workshop-planning/workshop-planning.component.ts
@@ -26,6 +26,9 @@ export class WorkshopPlanningComponent {
   @Input()
   weeklyReset: number;
 
+  @Input()
+  displayItemMetadata: boolean;
+
   planningAvailability = [0, 0, 1, 2, 3, 3, 3];
 
   days = [

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -3044,6 +3044,7 @@
       "Create_list": "Create a list for this planning",
       "Exclude_pasture_materials": "Exclude pasture materials",
       "Exclude_crop_materials": "Exclude crop materials",
+      "Display_item_metadata": "Display category and craft time of items in planning",
       "Groove_tooltip": "Groove at the end of the day",
       "Crafting_time": "Crafting time",
       "Categories": "Categories",

--- a/apps/client/src/assets/i18n/ja-JP.json
+++ b/apps/client/src/assets/i18n/ja-JP.json
@@ -3042,6 +3042,7 @@
       "Create_list": "このスケジュールでリストを作成",
       "Exclude_pasture_materials": "畜産物資を使わない",
       "Exclude_crop_materials": "耕作物資を使わない",
+      "Display_item_metadata": "特性と制作時間を表示する",
       "Groove_tooltip": "1日の終わりのやる気",
       "Crafting_time": "製作時間",
       "Categories": "特性",

--- a/apps/client/src/assets/i18n/zh-CN.json
+++ b/apps/client/src/assets/i18n/zh-CN.json
@@ -3042,6 +3042,7 @@
       "Create_list": "Create a list for this planning",
       "Exclude_pasture_materials": "Exclude pasture materials",
       "Exclude_crop_materials": "Exclude crop materials",
+      "Display_item_metadata": "显示物品分类及制作时间",
       "Groove_tooltip": "Groove at the end of the day",
       "Crafting_time": "Crafting time",
       "Categories": "Categories",


### PR DESCRIPTION
updated workshop planning to display item category and craft time

![image](https://user-images.githubusercontent.com/3547456/214179598-c5fc12e5-ad05-40cc-8f13-2a031d0490c9.png)

* added a toggle for this feature (defaults to true)
* added translations for CN and JP