### PR TITLE
fix(island-workshop): allowed items with undetermined C2 peak type to be considered for best item to use

### DIFF
--- a/apps/client/src/app/pages/island-workshop/optimizer/planning-formula-optimizer.ts
+++ b/apps/client/src/app/pages/island-workshop/optimizer/planning-formula-optimizer.ts
@@ -160,7 +160,7 @@ export class PlanningFormulaOptimizer {
 
   private getBestItems(projectedSupplyObjects: CraftworksObject[], objectsUsage: Record<number, number>): CraftworksObject[] {
     let items = projectedSupplyObjects
-      .filter((obj, i, array) => array.filter(e => e.craftworksEntry.themes.some(t => obj.craftworksEntry.themes.includes(t))) && obj.patterns.length === 1);
+      .filter((obj, i, array) => array.filter(e => e.craftworksEntry.themes.some(t => obj.craftworksEntry.themes.includes(t))) && obj.isPeaking);
 
     if (items.length === 0) {
       items = projectedSupplyObjects
@@ -182,7 +182,7 @@ export class PlanningFormulaOptimizer {
           return p.pattern[dayIndex][0];
         }).sort((a, b) => a - b)[0];
         object.hasPeaked = object.patterns.length === 1 && object.patterns[0].index < dayIndex;
-        object.isPeaking = object.patterns.length === 1 && object.patterns[0].index === dayIndex;
+        object.isPeaking = (object.patterns.length === 1 || object.patterns.length === 2) && object.patterns[0].index === dayIndex;
         return object;
       });
   }


### PR DESCRIPTION
With C2 patterns, C2 items will often not be distinguishable between strong or weak, so isPeaking can be true when it has 2 patterns.

Other cycles can have 2 patterns, but they would not have the right dayIndex so this will not errantly set isPeaking.