### PR TITLE
Fixed extra '0' in debounceTime call

### DIFF
--- a/apps/client/src/app/core/electron/ipc.service.ts
+++ b/apps/client/src/app/core/electron/ipc.service.ts
@@ -473,13 +473,13 @@ export class IpcService {
         });
     });
     this.on('pcap:status', (e, status) => this.pcapStatus$.next(status));
-    // If we don't get a packet for an entire minute, something is wrong.
+    // If we don't get a packet for two entire minutes, something is wrong.
     this.packets$.pipe(
       skipUntil(this.pcapToggle$.pipe(
         filter(Boolean)
       )),
       startWith(null),
-      debounceTime(1200000)
+      debounceTime(120000)
     ).subscribe(() => {
       this.pcapStatus$.next(PacketCaptureStatus.ERROR);
       this.send('log', {


### PR DESCRIPTION
The line was recently changed from 60000 ms (60 seconds) to 1200000 ms (1200 seconds), instead of the intended 120000 ms (120 seconds). Also, updated the comment :)