### PR TITLE
feat/voyage tracker UI enhancements

### DIFF
--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker.module.ts
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker.module.ts
@@ -15,6 +15,7 @@ import { NzPopoverModule } from 'ng-zorro-antd/popover';
 import { VesselRowComponent } from './voyage-tracker/vessel-row/vessel-row.component';
 import { VesselListComponent } from './voyage-tracker/vessel-list/vessel-list.component';
 import { VesselBuildColumnComponent } from './voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component';
+import { VesselRankColumnComponent } from './voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component';
 import { VesselVoyageColumnComponent } from './voyage-tracker/vessel-row/vessel-voyage-column/vessel-voyage-column.component';
 import { FormsModule } from '@angular/forms';
 import { FullpageMessageModule } from '../../modules/fullpage-message/fullpage-message.module';
@@ -33,6 +34,7 @@ const routes: Routes = [
     VesselRowComponent,
     VesselListComponent,
     VesselBuildColumnComponent,
+    VesselRankColumnComponent,
     VesselVoyageColumnComponent],
   imports: [
     CommonModule,

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.html
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.html
@@ -3,7 +3,7 @@
        [nzPopoverTitle]="name"
        [nzPopoverContent]="vesselBuildDetails"
   >
-    {{ vesselBuild?.abbreviation }}
+    <div [ngClass]="conditionClass()" class="condition">{{ vesselBuild?.abbreviation }} </div>
   </div>
 
   <ng-template #vesselBuildDetails>

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.html
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.html
@@ -3,7 +3,7 @@
        [nzPopoverTitle]="name"
        [nzPopoverContent]="vesselBuildDetails"
   >
-    <div [ngClass]="conditionClass()" class="condition">{{ vesselBuild?.abbreviation }} </div>
+    <div [ngClass]="conditionClass$ | async" class="condition">{{ vesselBuild?.abbreviation }} </div>
   </div>
 
   <ng-template #vesselBuildDetails>

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.less
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.less
@@ -1,0 +1,18 @@
+.condition {
+
+  &.good {
+    color: green;
+  }
+
+  &.caution {
+    color: yellow;
+  }
+
+  &.warn {
+    color: orange;
+  }
+
+  &.broken {
+    color: red;
+  }
+}

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.ts
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.ts
@@ -7,7 +7,7 @@ import { VesselType } from '../../../../../modules/free-company-workshops/model/
 import { observeInput } from '../../../../../core/rxjs/observe-input';
 import { combineLatest } from 'rxjs';
 import { safeCombineLatest } from '../../../../../core/rxjs/safe-combine-latest';
-import { switchMap } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-vessel-build-column',
@@ -31,6 +31,16 @@ export class VesselBuildColumnComponent {
   @Input() parts: Record<AirshipPartType, VesselPart> | Record<SubmarinePartType, VesselPart>;
 
   parts$ = observeInput(this, 'parts');
+
+  conditionClass$ = this.parts$.pipe(
+    map(parts => {
+      const worstCondition = Math.min(...Object.keys(parts).map((slot) => (parts[slot].condition || 0) / 300));
+      return {'good': worstCondition > 50,
+              'caution': worstCondition <= 50 && worstCondition > 25,
+              'warn': worstCondition <= 25 && worstCondition > 0,
+              'broken': worstCondition <= 0}
+    })
+  )
 
   fullNameParts$ = combineLatest([
     this.parts$,
@@ -57,13 +67,5 @@ export class VesselBuildColumnComponent {
 
   get condition(): string {
     return Object.keys(this.parts).map((slot) => `${((this.parts[slot].condition || 0) / 300).toFixed(2)}%`).join(' - ');
-  }
-
-  conditionClass(): object {
-    const worstCondition = Math.min(...Object.keys(this.parts).map((slot) => (this.parts[slot].condition || 0) / 300));
-    return {'good': worstCondition > 50,
-            'caution': worstCondition <= 50 && worstCondition > 25,
-            'warn': worstCondition <= 25 && worstCondition > 0,
-            'broken': worstCondition <= 0}
   }
 }

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.ts
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.ts
@@ -58,4 +58,12 @@ export class VesselBuildColumnComponent {
   get condition(): string {
     return Object.keys(this.parts).map((slot) => `${((this.parts[slot].condition || 0) / 300).toFixed(2)}%`).join(' - ');
   }
+
+  conditionClass(): object {
+    let worstCondition = Math.min(...Object.keys(this.parts).map((slot) => (this.parts[slot].condition || 0) / 300));
+    return {'good': worstCondition > 50,
+	    'caution': worstCondition <= 50 && worstCondition > 25,
+	    'warn': worstCondition <= 25 && worstCondition > 0,
+	    'broken': worstCondition <= 0}
+  }
 }

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.ts
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-build-column/vessel-build-column.component.ts
@@ -60,10 +60,10 @@ export class VesselBuildColumnComponent {
   }
 
   conditionClass(): object {
-    let worstCondition = Math.min(...Object.keys(this.parts).map((slot) => (this.parts[slot].condition || 0) / 300));
+    const worstCondition = Math.min(...Object.keys(this.parts).map((slot) => (this.parts[slot].condition || 0) / 300));
     return {'good': worstCondition > 50,
-	    'caution': worstCondition <= 50 && worstCondition > 25,
-	    'warn': worstCondition <= 25 && worstCondition > 0,
-	    'broken': worstCondition <= 0}
+            'caution': worstCondition <= 50 && worstCondition > 25,
+            'warn': worstCondition <= 25 && worstCondition > 0,
+            'broken': worstCondition <= 0}
   }
 }

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.html
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.html
@@ -12,7 +12,7 @@
   <div fxLaout="column">
     <div style="text-align: center">{{ currentExperience }} / {{ totalExperienceForNextRank }}</div>
     <div>
-      <nz-progress [nzPercent]="rankUpPercent()"></nz-progress>
+      <nz-progress [nzPercent]="rankupPercent$ | async"></nz-progress>
     </div>
   </div>
 </ng-template>

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.html
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.html
@@ -1,0 +1,18 @@
+<div *ngIf="rank > 0 && rank < maxRank" nz-popover
+     [nzPopoverTitle]="voyageRankTitle"
+     [nzPopoverContent]="voyageRankContent">
+  {{ rank }} / {{ maxRank }}
+</div>
+
+<ng-template #voyageRankTitle>
+  <div style="text-align: center">{{ 'VOYAGE_TRACKER.RANK_DETAILS.Experience_Points' | translate }}</div>
+</ng-template>
+
+<ng-template #voyageRankContent>
+  <div fxLaout="column">
+    <div style="text-align: center">{{ currentExperience }} / {{ totalExperienceForNextRank }}</div>
+    <div>
+      <nz-progress [nzPercent]="rankUpPercent()"></nz-progress>
+    </div>
+  </div>
+</ng-template>

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.ts
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.ts
@@ -11,8 +11,6 @@ import { observeInput } from '../../../../../core/rxjs/observe-input';
 export class VesselRankColumnComponent {
   @Input() rank: number;
 
-  vessel$ = observeInput(this, 'rank');
-
   @Input() currentExperience: number;
 
   currentExperience$ = observeInput(this, 'currentExperience');

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.ts
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.ts
@@ -1,6 +1,8 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { FreeCompanyWorkshopFacade } from '../../../../../modules/free-company-workshops/+state/free-company-workshop.facade';
 import { observeInput } from '../../../../../core/rxjs/observe-input';
+import { combineLatest } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-vessel-rank-column',
@@ -24,7 +26,9 @@ export class VesselRankColumnComponent {
   constructor(private freeCompanyWorkshopFacade: FreeCompanyWorkshopFacade) {
   }
 
-  rankUpPercent(): number {
-    return Math.round(100 * (this.currentExperience / this.totalExperienceForNextRank));
-  }
+  rankupPercent$ = combineLatest([this.currentExperience$, this.totalExperienceForNextRank$]).pipe(
+    map(([current, nextRank]) => {
+      return Math.round(100 * (current / nextRank));
+    })
+  )
 }

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.ts
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { FreeCompanyWorkshopFacade } from '../../../../../modules/free-company-workshops/+state/free-company-workshop.facade';
+import { observeInput } from '../../../../../core/rxjs/observe-input';
+
+@Component({
+  selector: 'app-vessel-rank-column',
+  templateUrl: './vessel-rank-column.component.html',
+  styleUrls: ['./vessel-rank-column.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class VesselRankColumnComponent {
+  @Input() rank: number;
+
+  vessel$ = observeInput(this, 'rank');
+
+  @Input() currentExperience: number;
+
+  currentExperience$ = observeInput(this, 'currentExperience');
+
+  @Input() totalExperienceForNextRank: number;
+
+  totalExperienceForNextRank$ = observeInput(this, 'totalExperienceForNextRank');
+
+  @Input() maxRank: number;
+
+  constructor(private freeCompanyWorkshopFacade: FreeCompanyWorkshopFacade) {
+  }
+
+  rankUpPercent(): number {
+    return Math.round(100 * (this.currentExperience / this.totalExperienceForNextRank));
+  }
+}

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-row.component.html
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-row.component.html
@@ -25,7 +25,13 @@
       </ng-template>
     </ng-template>
   </div>
-  <div fxFlex="0 0 90px" fxLayoutAlign="center center">{{ vessel?.rank }} / {{ maxRank }}</div>
+  <div fxFlex="0 0 90px" fxLayoutAlign="center center">
+    <app-vessel-rank-column [rank]="vessel?.rank"
+                            [currentExperience]="vessel?.currentExperience"
+                            [totalExperienceForNextRank]="vessel?.totalExperienceForNextRank"
+                            [maxRank]="maxRank"
+    ></app-vessel-rank-column>
+  </div>
   <div fxFlex="0 0 120px" fxLayoutAlign="center center">
     <app-vessel-build-column [type]="vessel?.vesselType"
                              [name]="vessel?.name"

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -2783,6 +2783,9 @@
       "Speed": "Speed",
       "Range": "Range",
       "Favor": "Favor"
+    },
+    "RANK_DETAILS": {
+      "Experience_Points": "Experience Points"
     }
   },
   "AIRSHIP": {


### PR DESCRIPTION
This is two small changes to show a little more info in the voyage tracker.

1) The abbreviated build in the build column is now colored to give an indication of the worst condition on the parts so it's easier to tell when a vehicle needs to be repaired without having to mouse over the build and look at the popup. It would be possible to instead color each part letter separately but that was more effort, would perhaps be enough extra color to be distracting, and it's generally sufficient to know the worst part condition because parts with higher than 0 don't need to be repaired anyway. Still, I'm not thrilled with how this looks and maybe it would be better to have a vertical red/green bar kind of icon like we see in game shown next to the build abbreviation.
2) Added a popover to the ranks column to show current / next level experience points, and a progress bar, for vehicles that aren't at max rank. When leveling a vehicle it can be convenient to know how close you are to reaching a new rank and I don't think this information was displayed anywhere in Teamcraft previously.

Please let me know if I have made silly errors or done things in a strange way. I'm not very familiar at all with TypeScript/Angular/any front-end web stuff so I kind of just tried to figure it out as I was going here.