### PR TITLE
fix(voyage-tracker): display rank when at max rank

### DIFF
--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.html
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-rank-column/vessel-rank-column.component.html
@@ -1,8 +1,12 @@
-<div *ngIf="rank > 0 && rank < maxRank" nz-popover
+<div *ngIf="rank > 0 && rank < maxRank; else noPopover" nz-popover
      [nzPopoverTitle]="voyageRankTitle"
      [nzPopoverContent]="voyageRankContent">
   {{ rank }} / {{ maxRank }}
 </div>
+
+<ng-template #noPopover>
+  {{ rank }} / {{ maxRank }}
+</ng-template>
 
 <ng-template #voyageRankTitle>
   <div style="text-align: center">{{ 'VOYAGE_TRACKER.RANK_DETAILS.Experience_Points' | translate }}</div>


### PR DESCRIPTION
XP progress popover is disabled though since max rank vehicles are unable to earn any XP.