### PR TITLE
fix(custom-alarm-without-weather): custom alarm without weather are now properly displayed

### DIFF
--- a/apps/client/src/app/core/alarms/+state/alarms.facade.ts
+++ b/apps/client/src/app/core/alarms/+state/alarms.facade.ts
@@ -284,7 +284,8 @@ export class AlarmsFacade {
   }
 
   public createDisplayArray<T extends AlarmDetails | PersistedAlarm = PersistedAlarm>(alarms: T[], date: Date): AlarmDisplay<T>[] {
-    return this.sortAlarmDisplays(alarms.map(alarm => {
+    return this.sortAlarmDisplays(alarms.filter(alarm => alarm.spawns !== undefined || alarm.weathers !== undefined)
+      .map(alarm => {
         return this.createDisplay(alarm, date);
       }));
   }

--- a/apps/client/src/app/core/alarms/+state/alarms.facade.ts
+++ b/apps/client/src/app/core/alarms/+state/alarms.facade.ts
@@ -284,8 +284,7 @@ export class AlarmsFacade {
   }
 
   public createDisplayArray<T extends AlarmDetails | PersistedAlarm = PersistedAlarm>(alarms: T[], date: Date): AlarmDisplay<T>[] {
-    return this.sortAlarmDisplays(alarms.filter(alarm => alarm.spawns !== undefined || alarm.weathers !== undefined)
-      .map(alarm => {
+    return this.sortAlarmDisplays(alarms.map(alarm => {
         return this.createDisplay(alarm, date);
       }));
   }

--- a/apps/client/src/app/modules/custom-alarm-popup/custom-alarm-popup/custom-alarm-popup.component.ts
+++ b/apps/client/src/app/modules/custom-alarm-popup/custom-alarm-popup/custom-alarm-popup.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { AbstractControl, UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { combineLatest, Observable } from 'rxjs';
 import { XivapiEndpoint, XivapiService } from '@xivapi/angular-client';
 import { filter, map, shareReplay, startWith } from 'rxjs/operators';
@@ -129,6 +129,19 @@ export class CustomAlarmPopupComponent implements OnInit {
       y: [this.y, [Validators.min(this.Y_VALIDATOR.min), Validators.max(this.Y_VALIDATOR.max)]],
       weathers: [this.weathers],
       weathersFrom: [this.weathersFrom]
+    }, {
+      validators: (control: AbstractControl) => {
+        const spawn = control.value.spawn;
+        const weather = (control.value.weathers && control.value.weathers.length > 0);
+        if (spawn || weather) {
+          return null;
+        }
+
+        return {
+          spawn: true,
+          weathers : true
+         };
+      }
     });
 
     this.mapWeathers$ = combineLatest([this.form.valueChanges, this.maps$]).pipe(

--- a/apps/client/src/app/modules/custom-alarm-popup/custom-alarm-popup/custom-alarm-popup.component.ts
+++ b/apps/client/src/app/modules/custom-alarm-popup/custom-alarm-popup/custom-alarm-popup.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { combineLatest, Observable } from 'rxjs';
 import { XivapiEndpoint, XivapiService } from '@xivapi/angular-client';
-import { filter, map, shareReplay } from 'rxjs/operators';
+import { filter, map, shareReplay, startWith } from 'rxjs/operators';
 import { PersistedAlarm } from '../../../core/alarms/persisted-alarm';
 import { AlarmsFacade } from '../../../core/alarms/+state/alarms.facade';
 import { NzModalRef } from 'ng-zorro-antd/modal';
@@ -137,8 +137,12 @@ export class CustomAlarmPopupComponent implements OnInit {
       }),
       filter(m => m !== undefined),
       map((m: { TerritoryType: { WeatherRate: number } }) => {
-        return _.uniq(weatherIndex[m.TerritoryType.WeatherRate].map(row => +row.weatherId)) as number[];
+        const defaultWeather = weatherIndex[m.TerritoryType.WeatherRate];
+        if (defaultWeather != undefined)  {
+          return _.uniq(defaultWeather.map(row => +row.weatherId)) as number[];
+        }
       }),
+      startWith([]),
       shareReplay({ bufferSize: 1, refCount: true })
     );
   }

--- a/apps/client/src/app/pages/alarms-page/alarms-page/alarms-page.component.html
+++ b/apps/client/src/app/pages/alarms-page/alarms-page/alarms-page.component.html
@@ -226,12 +226,12 @@
           <div *ngIf="row.alarm.mapId | closestAetheryte:row.alarm.coords | async as aetheryte">
             {{aetheryte.nameid | i18nRow:'places' | i18n}}
           </div>
-          <div>
+          <div *ngIf="row.alarm.spawns">
             <span *ngFor="let spawn of row.alarm.spawns; last as last">
               {{spawn}}:00 - {{(spawn + row.alarm.duration) % 24}}:00<span *ngIf="!last">,&nbsp;</span>
             </span>
           </div>
-          <div fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
+          <div *ngIf="row.remainingTime" fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
             <div [timerTooltip]="row.remainingTime">{{row.remainingTime | timer}}</div>
             <div *ngIf="row.alarm.nodeContent" [nzPopoverContent]="nodeContent"
                  [nzPopoverTitle]="'ALARMS.Node_content' | translate"
@@ -263,7 +263,7 @@
                 <i nz-icon nzType="right" theme="outline"></i>
               </div>
             </ng-container>
-            <div fxLayout="row wrap" fxLayoutGap="5px">
+            <div *ngIf="row.alarm.weathers" fxLayout="row wrap" fxLayoutGap="5px">
               <div *ngFor="let weather of row.alarm.weathers">
                 <img [nzTooltipTitle]="weather | i18nRow:'weathers' | i18n" [src]="weather | weatherIcon" alt="{{weather | i18nRow:'weathers' | i18n}}"
                      nz-tooltip>
@@ -383,7 +383,7 @@
                src="./assets/icons/status/snagging.png">
         </div>
         <div nz-col nzMd="2">
-          <div fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
+          <div *ngIf="row.remainingTime" fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
             <div [timerTooltip]="row.remainingTime">{{row.remainingTime | timer}}</div>
             <div *ngIf="row.alarm.nodeContent" [nzPopoverContent]="nodeContent"
                  [nzPopoverTitle]="'ALARMS.Node_content' | translate"


### PR DESCRIPTION
Adding a default value for weather on custom alarm form Allow alarm with missing spawns and remaining time to be displayed