### PR TITLE
feat(add-reminder-for-ocean-fishing): add a new reminder for ocean fishing every two hours

### DIFF
--- a/apps/client/src/app/core/alarms/realtime-alarms.service.ts
+++ b/apps/client/src/app/core/alarms/realtime-alarms.service.ts
@@ -17,11 +17,12 @@ import { addHours } from 'date-fns';
 @Injectable({ providedIn: 'root' })
 export class RealtimeAlarmsService {
 
-  public static readonly REAL_TIME_ALARMS: { [idnex: string]: RealtimeAlarm } = {
+  public static readonly REAL_TIME_ALARMS: { [index: string]: RealtimeAlarm } = {
     'WEEKLY_RESETS': new RealtimeAlarm([8], 'WEEKLY_RESETS', UtcDay.TUESDAY),
     'ROULETTES_RESET': new RealtimeAlarm([15], 'ROULETTES_RESET'),
     'DELIVERIES_RESET': new RealtimeAlarm([20], 'DELIVERIES_RESET'),
-    'LEVE_ALLOWANCES': new RealtimeAlarm([0, 12], 'LEVE_ALLOWANCES')
+    'LEVE_ALLOWANCES': new RealtimeAlarm([0, 12], 'LEVE_ALLOWANCES'),
+    'OCEAN_FISHING': new RealtimeAlarm(new Array(12).fill(null).map((_, i) => i * 2), 'OCEAN_FISHING')
   };
 
   private reloader$ = new BehaviorSubject(null);
@@ -116,7 +117,7 @@ export class RealtimeAlarmsService {
     nextIteration.setUTCSeconds(0);
     nextIteration.setUTCMilliseconds(0);
     nextIteration.setUTCHours(hour);
-    if (new Date().getUTCHours() > hour && day === undefined) {
+    if (new Date().getUTCHours() >= hour && day === undefined) {
       nextIteration = addHours(nextIteration, 24);
     }
     if (day !== undefined) {

--- a/apps/client/src/assets/i18n/de-DE.json
+++ b/apps/client/src/assets/i18n/de-DE.json
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "Liefereinsätze",
       "DELIVERIES_RESET_DESCRIPTION": "Reset der Liefereinsätze der Staatlichen Gesellschaft",
       "LEVE_ALLOWANCES": "Verfügbare Freibriefe",
-      "LEVE_ALLOWANCES_DESCRIPTION": "Du erhältst 3 weitere Vollmachten"
+      "LEVE_ALLOWANCES_DESCRIPTION": "Du erhältst 3 weitere Vollmachten",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "Eigenen Alarm hinzufügen",

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -252,7 +252,7 @@
     "Click_to_show_all_alarms": "Click to show all alarms",
     "Enable_TTS": "Enable Text-to-Speech",
     "REALTIME": {
-      "Reset_timers": "Reset timers",
+      "Reset_timers": "Reminders",
       "WEEKLY_RESETS": "Weeklies",
       "WEEKLY_RESETS_DESCRIPTION": "Custom deliveries, WT, Weekly drops (24-man raids, savage tokens, NM raid's weapon token), Jumbo Cactpot, Challenge Log, Fashion Report, B-Rank Hunt marks.",
       "ROULETTES_RESET": "Roulettes & Beast tribes",
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "Deliveries",
       "DELIVERIES_RESET_DESCRIPTION": "Reset of GC hand-ins",
       "LEVE_ALLOWANCES": "Leve allowances",
-      "LEVE_ALLOWANCES_DESCRIPTION": "You get 3 more leve allowances"
+      "LEVE_ALLOWANCES_DESCRIPTION": "You get 3 more leve allowances",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "Add custom alarm",

--- a/apps/client/src/assets/i18n/es-ES.json
+++ b/apps/client/src/assets/i18n/es-ES.json
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "Entregas",
       "DELIVERIES_RESET_DESCRIPTION": "Restablecimiento de entregas de la GC",
       "LEVE_ALLOWANCES": "Permisos de leve",
-      "LEVE_ALLOWANCES_DESCRIPTION": "Obtiene 3 permisos de leve más"
+      "LEVE_ALLOWANCES_DESCRIPTION": "Obtiene 3 permisos de leve más",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "Agregar alarma personalizada",

--- a/apps/client/src/assets/i18n/fr-FR.json
+++ b/apps/client/src/assets/i18n/fr-FR.json
@@ -252,7 +252,7 @@
     "Click_to_show_all_alarms": "Cliquez pour afficher toutes les alarmes",
     "Enable_TTS": "Activer la synthèse vocale",
     "REALTIME": {
-      "Reset_timers": "Remises à zéro",
+      "Reset_timers": "Rappels",
       "WEEKLY_RESETS": "Resets hebdos",
       "WEEKLY_RESETS_DESCRIPTION": "Commandes spéciales, Carnet de Khloé, Récompenses hebdomadaires (raids 24 joueurs, raids sadiques, raids 8 joueurs), Méga Cactpot, Carnet d'objectifs, Revue de Mode, Chasse Rang B.",
       "ROULETTES_RESET": "Roulettes et quêtes tribales",
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "Livraisons",
       "DELIVERIES_RESET_DESCRIPTION": "Réinitialisation des livraisons de grande compagnie",
       "LEVE_ALLOWANCES": "Autorisations de mandats",
-      "LEVE_ALLOWANCES_DESCRIPTION": "Vous obtenez 3 nouvelles autorisations de mandats"
+      "LEVE_ALLOWANCES_DESCRIPTION": "Vous obtenez 3 nouvelles autorisations de mandats",
+      "OCEAN_FISHING" : "Pêche en mer",
+      "OCEAN_FISHING_DESCRIPTION" : "La pêche en mer va commencer."
     },
     "CUSTOM": {
       "Title": "Ajouter une alarme personnalisée",

--- a/apps/client/src/assets/i18n/hr-HR.json
+++ b/apps/client/src/assets/i18n/hr-HR.json
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "Deliveries",
       "DELIVERIES_RESET_DESCRIPTION": "Reset of GC hand-ins",
       "LEVE_ALLOWANCES": "Leve allowances",
-      "LEVE_ALLOWANCES_DESCRIPTION": "You get 3 more leve allowances"
+      "LEVE_ALLOWANCES_DESCRIPTION": "You get 3 more leve allowances",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "Dodajte zadani alarm",

--- a/apps/client/src/assets/i18n/ja-JP.json
+++ b/apps/client/src/assets/i18n/ja-JP.json
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "調達依頼",
       "DELIVERIES_RESET_DESCRIPTION": "調達任務リセット",
       "LEVE_ALLOWANCES": "リーヴ受注権",
-      "LEVE_ALLOWANCES_DESCRIPTION": "リーヴ受注権3枚獲得"
+      "LEVE_ALLOWANCES_DESCRIPTION": "リーヴ受注権3枚獲得",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "カスタムアラームを追加する",

--- a/apps/client/src/assets/i18n/ko-KR.json
+++ b/apps/client/src/assets/i18n/ko-KR.json
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "조달 임무",
       "DELIVERIES_RESET_DESCRIPTION": "총사령부 조달 품목 초기화",
       "LEVE_ALLOWANCES": "의뢰 수주권",
-      "LEVE_ALLOWANCES_DESCRIPTION": "의뢰 수주권 3장 획득"
+      "LEVE_ALLOWANCES_DESCRIPTION": "의뢰 수주권 3장 획득",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "사용자 지정 알람 추가",

--- a/apps/client/src/assets/i18n/nl-NL.json
+++ b/apps/client/src/assets/i18n/nl-NL.json
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "Deliveries",
       "DELIVERIES_RESET_DESCRIPTION": "Reset of GC hand-ins",
       "LEVE_ALLOWANCES": "Leve allowances",
-      "LEVE_ALLOWANCES_DESCRIPTION": "You get 3 more leve allowances"
+      "LEVE_ALLOWANCES_DESCRIPTION": "You get 3 more leve allowances",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "Add custom alarm",

--- a/apps/client/src/assets/i18n/pt-BR.json
+++ b/apps/client/src/assets/i18n/pt-BR.json
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "Entregas",
       "DELIVERIES_RESET_DESCRIPTION": "Reset of GC hand-ins",
       "LEVE_ALLOWANCES": "Leve allowances",
-      "LEVE_ALLOWANCES_DESCRIPTION": "You get 3 more leve allowances"
+      "LEVE_ALLOWANCES_DESCRIPTION": "You get 3 more leve allowances",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "Adicionar alarme personalizado",

--- a/apps/client/src/assets/i18n/pt-PT.json
+++ b/apps/client/src/assets/i18n/pt-PT.json
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "Entregas",
       "DELIVERIES_RESET_DESCRIPTION": "Reset das entregas da GC",
       "LEVE_ALLOWANCES": "Permissões de Leves",
-      "LEVE_ALLOWANCES_DESCRIPTION": "Recebe mais 3 permissões de Leves"
+      "LEVE_ALLOWANCES_DESCRIPTION": "Recebe mais 3 permissões de Leves",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "Adicionar alarme personalizado",

--- a/apps/client/src/assets/i18n/ru-RU.json
+++ b/apps/client/src/assets/i18n/ru-RU.json
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "Доставки",
       "DELIVERIES_RESET_DESCRIPTION": "Сброс доставок для Grand Company",
       "LEVE_ALLOWANCES": "Разрешения ливквестов",
-      "LEVE_ALLOWANCES_DESCRIPTION": "Вы получите 3 разрешения для ливквестов"
+      "LEVE_ALLOWANCES_DESCRIPTION": "Вы получите 3 разрешения для ливквестов",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "Добавить настраиваемое оповещение",

--- a/apps/client/src/assets/i18n/zh-CN.json
+++ b/apps/client/src/assets/i18n/zh-CN.json
@@ -260,7 +260,9 @@
       "DELIVERIES_RESET": "军团筹备",
       "DELIVERIES_RESET_DESCRIPTION": "军团筹备CD刷新倒计时",
       "LEVE_ALLOWANCES": "理符受理限额",
-      "LEVE_ALLOWANCES_DESCRIPTION": "您将获得3个新的理符受理限额"
+      "LEVE_ALLOWANCES_DESCRIPTION": "您将获得3个新的理符受理限额",
+      "OCEAN_FISHING" : "Ocean fishing",
+      "OCEAN_FISHING_DESCRIPTION" : "Ocean fishing will start."
     },
     "CUSTOM": {
       "Title": "添加自定义闹钟",


### PR DESCRIPTION
You can now enable a reminder for ocean fishing on reminders page