### PR TITLE
fix(accessibility): add lang attribute to html

### DIFF
--- a/apps/client/src/app/app.component.ts
+++ b/apps/client/src/app/app.component.ts
@@ -47,7 +47,7 @@ import { CustomItemsFacade } from './modules/custom-items/+state/custom-items.fa
 import { DirtyFacade } from './core/dirty/+state/dirty.facade';
 import { SeoService } from './core/seo/seo.service';
 import { Theme } from './modules/settings/theme';
-import { isPlatformBrowser, isPlatformServer } from '@angular/common';
+import { DOCUMENT, isPlatformBrowser, isPlatformServer } from '@angular/common';
 import { REQUEST } from '@nguniversal/express-engine/tokens';
 import * as semver from 'semver';
 import { UniversalisService } from './core/api/universalis.service';
@@ -232,7 +232,8 @@ export class AppComponent implements OnInit {
 
   public currentLink = () => `https://ffxivteamcraft.com${window.location.hash.replace('#', '')}`;
 
-  constructor(private gt: GarlandToolsService, public translate: TranslateService,
+  constructor(@Inject(DOCUMENT) private document: Document,
+              private gt: GarlandToolsService, public translate: TranslateService,
               public ipc: IpcService, private router: Router, private firebase: Database,
               private authFacade: AuthFacade, private dialog: NzModalService, private eorzeanTime: EorzeanTimeService,
               public listsFacade: ListsFacade, private workshopsFacade: WorkshopsFacade, public settings: SettingsService,
@@ -757,6 +758,7 @@ export class AppComponent implements OnInit {
     if (!fromIpc) {
       this.ipc.send('language', lang);
     }
+    this.document.documentElement.lang = lang;
   }
 
   startTutorial(): void {

--- a/apps/client/src/index.html
+++ b/apps/client/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html xmlns:og="http://ogp.me/ns#">
+<html xmlns:og="http://ogp.me/ns#" lang="en">
 <head>
   <title>FFXIV Teamcraft</title>
   <meta name="description"


### PR DESCRIPTION
This PR sets `html[lang]` with the current language, and updates it if the language is changed while in the SPA.

## Motivation

On the web it helps browsers, translation tools, and screen readers if the language of the content is defined in `html[lang]`.

For example:

* Translation tools know what to translate the page from without user input.
* Screen readers know what language/accent to use when reading content.

## References

> This Success Criterion helps:
>
> * people who use screen readers or other technologies that convert text into synthetic speech;
> * people who find it difficult to read written material with fluency and accuracy, such as recognizing characters and alphabets or decoding words;
> * people with certain cognitive, language and learning disabilities who use text-to-speech software
> * people who rely on captions for synchronized media.
>
> — [Web Content Accessibility Guidelines: Language of Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page)

> WCAG Success Criterion 3.1.1 requires that a page language is specified in a way which may be 'programmatically determined' (i.e. via the lang attribute).
> …
> The purpose of these requirements is primarily to allow assistive technologies such as screen readers to invoke the correct pronunciation.
> 
> — [MDN Web Docs: lang attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)