### PR TITLE
fix(i18n): en language file

### DIFF
--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -1254,7 +1254,7 @@
       "Use_more_quality_actions": "You have remaining durability at the end of the craft, you should probably use it to add more quality-related actions.",
       "Use_prudent_touch_manipulation": "As you are level 66+, you should use Manipulation + Prudent Touch combo for quality gain in order to get maximum quality benefit ans more reliability.",
       "Use_rapid_synthesis_earlier": "You should not use Rapid Synthesis as a finisher action, putting it earlier in order to be able to handle the failure of the action is better for your rotation's reliability.",
-      "Avoid_using_good_actions": "Avoid using actions that require the Good state in a macro, as they can't be predicted",
+      "Avoid_using_good_actions": "Avoid using actions that require the Good state in a macro, as they can't be predicted"
     }
   },
   "PRICING": {


### PR DESCRIPTION
Removes an unnecessary comma in the English language file.
While removing translation keys, an extra comma was left in, so now it's invalid JSON.

Firefox no longer shows the English UI with the staging branch.

## Related

* Introduced in https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/commit/927a7d65e74d8ced66fe703b82dc3c9b5138872f#diff-def7e78050b579a674ce4e511d200b764375bfe975ce8bcb03568b85607d8c22L1267