### PR TITLE
11.0.3 with a trades popup hotfix

### DIFF
--- a/apps/client/src/app/modules/item-details/trades/trades.component.html
+++ b/apps/client/src/app/modules/item-details/trades/trades.component.html
@@ -6,7 +6,7 @@
       </ng-template>
     </nz-card-meta>
     <div nz-row>
-      <div *ngFor="let trade of tradeSource.trades" class="trades" nz-col [nzMd]="6" [nzSm]="12" [nzXs]="24">
+      <div *ngFor="let trade of tradeSource.trades" class="trades" nz-col [nzMd]="8" [nzSm]="12" [nzXs]="24">
         <div fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="5px">
           <div *ngFor="let currency of trade.currencies" class="item-container flex-row align-center gap-2">
             <app-item-icon [hq]="currency.hq" [icon]="currency.icon" [itemId]="+currency.id"

--- a/apps/client/src/app/modules/list/item/item-sources-display/item-sources-display.component.ts
+++ b/apps/client/src/app/modules/list/item/item-sources-display/item-sources-display.component.ts
@@ -176,7 +176,7 @@ export class ItemSourcesDisplayComponent extends TeamcraftComponent {
         nzComponentParams: {
           item: item,
           details: getItemSource(item, dataType),
-          dbDisplay: true
+          dbDisplay: this.dbDisplay
         },
         nzFooter: null
       });

--- a/apps/client/src/assets/i18n/de-DE.json
+++ b/apps/client/src/assets/i18n/de-DE.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "G.-St.",
     "Cost": "Kosten",
     "Class_job": "Klasse/Job",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "Requires a masterbook"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "Gegenstände, die in mehreren Inventaren enthalten sind",
       "Message": "Dieser Gegenstand ist ebenfalls in folgendem Inventar enthalten: {{containers}}."
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "Gegenstände, die du in sehr kleinen Stapeln hast",

--- a/apps/client/src/assets/i18n/es-ES.json
+++ b/apps/client/src/assets/i18n/es-ES.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "ilvl",
     "Cost": "Costo",
     "Class_job": "Clase/Profesión",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "Requires a masterbook"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "Artículos duplicados en múltiples contenedores",
       "Message": "Este elemento también está presente en: {{containers}}."
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "Objetos que tiene en pilas muy pequeñas",

--- a/apps/client/src/assets/i18n/fr-FR.json
+++ b/apps/client/src/assets/i18n/fr-FR.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "ilvl",
     "Cost": "Coût",
     "Class_job": "Classe/Job",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "Requires a masterbook"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "Éléments qui sont dupliqués à travers plusieurs conteneurs",
       "Message": "Cet objet est également présent dans : {{containers}}."
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "Objets que vous avez en très petite quantité",

--- a/apps/client/src/assets/i18n/hr-HR.json
+++ b/apps/client/src/assets/i18n/hr-HR.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "ilvl",
     "Cost": "Cost",
     "Class_job": "Class/Job",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "Requires a masterbook"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "Items that are duplicated across multiple containers",
       "Message": "This item is also present in: {{containers}}."
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "Items that you have in very small stacks",

--- a/apps/client/src/assets/i18n/ja-JP.json
+++ b/apps/client/src/assets/i18n/ja-JP.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "IL",
     "Cost": "費用",
     "Class_job": "ジョブ",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "Requires a masterbook"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "アイテムが複数の場所に分散されています",
       "Message": "このアイテムは{{containers}} もあります"
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "少量で所有しているアイテム",

--- a/apps/client/src/assets/i18n/ko-KR.json
+++ b/apps/client/src/assets/i18n/ko-KR.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "아이템레벨",
     "Cost": "CP",
     "Class_job": "클래스/직업",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "비전서 필요"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "여러 곳에 분산된 아이템",
       "Message": "이 아이템은 {{containers}} 에도 있습니다"
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "매우 소량으로 소유하고 있는 아이템",

--- a/apps/client/src/assets/i18n/nl-NL.json
+++ b/apps/client/src/assets/i18n/nl-NL.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "ilvl",
     "Cost": "Cost",
     "Class_job": "Class/Job",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "Requires a masterbook"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "Items that are duplicated across multiple containers",
       "Message": "This item is also present in: {{containers}}."
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "Items that you have in very small stacks",

--- a/apps/client/src/assets/i18n/pt-BR.json
+++ b/apps/client/src/assets/i18n/pt-BR.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "ilvl",
     "Cost": "Custo",
     "Class_job": "Class/Job",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "Requires a masterbook"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "Items that are duplicated across multiple containers",
       "Message": "This item is also present in: {{containers}}."
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "Items that you have in very small stacks",

--- a/apps/client/src/assets/i18n/pt-PT.json
+++ b/apps/client/src/assets/i18n/pt-PT.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "ilvl",
     "Cost": "Custo",
     "Class_job": "Classe/Profissão",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "Requires a masterbook"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "Items that are duplicated across multiple containers",
       "Message": "This item is also present in: {{containers}}."
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "Items that you have in very small stacks",

--- a/apps/client/src/assets/i18n/ru-RU.json
+++ b/apps/client/src/assets/i18n/ru-RU.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "ilvl",
     "Cost": "Стоимость",
     "Class_job": "Класс/Профессия",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "Requires a masterbook"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "Элементы, дублирующиеся по нескольким ретейнерам",
       "Message": "Этот предмет также присутствует в: {{containers}}."
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "Предметы, которые у вас есть в маленьком количестве",

--- a/apps/client/src/assets/i18n/zh-CN.json
+++ b/apps/client/src/assets/i18n/zh-CN.json
@@ -1381,6 +1381,10 @@
     "Ilvl": "品级",
     "Cost": "消耗",
     "Class_job": "职业/特职",
+    "Damage_phys": "Phys. Damage",
+    "Damage_mag": "Mag. Damage",
+    "Defense_phys": "Phys. Defense",
+    "Defense_mag": "Mag. Defense",
     "Masterbooks": "Requires a masterbook"
   },
   "SEARCH_INTRO": {
@@ -2090,6 +2094,10 @@
     "DUPLICATES": {
       "Title": "存放在多个物品栏的物品",
       "Message": "物品还存放于： {{containers}}。"
+    },
+    "NOT_IN_LIST": {
+      "Title": "Items that are not used in any of your lists",
+      "Message": "This item is not used in any of your lists."
     },
     "HAS_TOO_FEW": {
       "Title": "持有数量非常少的物品",

--- a/libs/data/src/lib/lazy-files-list.ts
+++ b/libs/data/src/lib/lazy-files-list.ts
@@ -497,7 +497,7 @@ export const lazyFilesList = {
   },
   'quests': {
     'fileName': 'quests.json',
-    'hashedFileName': 'quests.92be1802200399332439991b971ddc2011875503.json'
+    'hashedFileName': 'quests.43a080b69498e6f54ca8f22d79ef19e7d280f88f.json'
   },
   'races': {
     'fileName': 'races.json',


### PR DESCRIPTION
### Features

* **desktop:** new option in tray menu to toggle always on top.
* **inventory-optimizer:** new "items not used in any of your lists" optimizer.
* **tooltips:** added rlvl and quality to recipe details.


### Bug Fixes

* **core:** hide desktop tip banner on mobile.
* **db:** fixed items showing wrong value for Class/job.
* **db:** fixed progress value not shown on recipe details.
* **ios:** possible fix for older ios browsers.
* **list:** monster icon is now larger.
* **lists:** fixed "mark panel content as done" on offline lists.
* **simulator:** fixed a bug preventing custom rotations from saving.
* **simulator:** fixed rotation finder not loading and poor simulator perfs.
* **tooltips:** added 500ms delay before closing and they now stay opened on mouseover.