### PR TITLE
fix(ios): fix notification check on iOS

### DIFF
--- a/apps/client/src/app/core/push-notifications.service.ts
+++ b/apps/client/src/app/core/push-notifications.service.ts
@@ -9,7 +9,7 @@ export class PushNotificationsService {
   public permission: 'default' | NotificationPermission = 'default';
 
   isSupported(): boolean {
-    return !!Notification;
+    return 'Notification' in window;
   }
 
   requestPermission(): void {


### PR DESCRIPTION
Accessing `!!Notification` is failing on iOS. Using the official check `'Notification' in window` fixed the issue. I tested it with iOS Safari, iPad Safari and Chrome on Windows.

Alerting will not work as this will return `false` on the check. iOS Safari is supporting the Notification API since 16.4, so it SHOULD be possible to get it working with the limitation of having to add the site to the home screen first. But I think this is for another PR :) My highest prio was getting the site to load again.

The firebase errors were false flags and the only real problem was the notification check crashing the whole app after all.