### PR TITLE
fix(simulator): Fix logic for manipulation check in use-durability-restoration-later tip

### DIFF
--- a/apps/client/src/app/pages/simulator/rotation-tips/tips/use-durability-restoration-later.ts
+++ b/apps/client/src/app/pages/simulator/rotation-tips/tips/use-durability-restoration-later.ts
@@ -34,7 +34,8 @@ export class UseDurabilityRestorationLater extends RotationTip {
     });
 
     const usedManipulationTooEarly = manipulationIIIndexes.some((index) => {
-      const repairSteps = simulationResult.steps.filter(s => !s.action.skipsBuffTicks()).slice(index + 1, index + 1 + new Manipulation().getDuration(simulationResult.simulation));
+      // Get all steps after Manipulation, then remove any skipsBuffTicks() steps, then get the first Manipulation.getDuration() steps.
+      const repairSteps = simulationResult.steps.slice(index + 1, simulationResult.steps.length).filter(s => !s.action.skipsBuffTicks()).slice(0, new Manipulation().getDuration(simulationResult.simulation));
       const matches = repairSteps.some(step => {
         return step.afterBuffTick.solidityDifference === 0 && step.solidityDifference === 0;
       });


### PR DESCRIPTION
See issue https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/issues/2686, bug: use-durability-restoration-later tip does not adjust index for filtered steps