### PR TITLE
Allow EN locale users to specify their Date Format

### DIFF
--- a/apps/client/src/app/app.component.ts
+++ b/apps/client/src/app/app.component.ts
@@ -83,6 +83,8 @@ export class AppComponent implements OnInit {
 
   public availableLanguages = this.settings.availableLocales;
 
+  public availableDateLocales = this.settings.availableLocales;
+
   public pcapStatus$: Observable<NzBadgeStatusType> = this.ipc.pcapStatus$.pipe(
     map(status => {
       return (<Record<PacketCaptureStatus, NzBadgeStatusType>>{

--- a/apps/client/src/app/app.module.ts
+++ b/apps/client/src/app/app.module.ts
@@ -81,6 +81,7 @@ import { WorkshopModule } from './modules/workshop/workshop.module';
 import { LayoutModule } from '@angular/cdk/layout';
 import { CustomItemsModule } from './modules/custom-items/custom-items.module';
 import en from '@angular/common/locales/en';
+import enGB from '@angular/common/locales/en-GB';
 import fr from '@angular/common/locales/fr';
 import de from '@angular/common/locales/de';
 import ja from '@angular/common/locales/ja';
@@ -164,6 +165,7 @@ const icons: IconDefinition[] = [
 ];
 
 registerLocaleData(en);
+registerLocaleData(enGB);
 registerLocaleData(fr);
 registerLocaleData(de);
 registerLocaleData(ja);

--- a/apps/client/src/app/modules/comments/comments-popup/comments-popup.component.html
+++ b/apps/client/src/app/modules/comments/comments-popup/comments-popup.component.html
@@ -2,7 +2,7 @@
   <nz-list [nzDataSource]="comments" [nzRenderItem]="commentTemplate" nzSize="small">
     <ng-template #commentTemplate let-comment>
       <nz-list-item [nzActions]="isAuthor?[delete]:null">
-        <nz-list-item-meta [nzAvatar]="avatar" [nzDescription]="comment.date | date:'short'"
+        <nz-list-item-meta [nzAvatar]="avatar" [nzDescription]="comment.date | date:'short':null:settings.dateFormat"
                            [nzTitle]="contentRef">
           <ng-template #contentRef>
             <p>{{comment.content}}</p>

--- a/apps/client/src/app/modules/comments/comments-popup/comments-popup.component.ts
+++ b/apps/client/src/app/modules/comments/comments-popup/comments-popup.component.ts
@@ -7,6 +7,7 @@ import { AuthFacade } from '../../../+state/auth.facade';
 import { shareReplay } from 'rxjs/operators';
 import { AbstractNotification } from '../../../core/notification/abstract-notification';
 import { NotificationService } from '../../../core/notification/notification.service';
+import { SettingsService } from '../../settings/settings.service';
 
 @Component({
   selector: 'app-comments-popup',
@@ -32,7 +33,7 @@ export class CommentsPopupComponent implements OnInit {
   userId$ = this.authFacade.userId$.pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
   constructor(private commentsService: CommentsService, private authFacade: AuthFacade,
-              private notificationService: NotificationService) {
+              private notificationService: NotificationService, public settings: SettingsService) {
   }
 
   ngOnInit() {

--- a/apps/client/src/app/modules/commission-board/commission-panel/commission-panel.component.html
+++ b/apps/client/src/app/modules/commission-board/commission-panel/commission-panel.component.html
@@ -11,7 +11,7 @@
           </nz-badge>
         </div>
         <div nz-col nzMd="4" nzSm="12" fxLayout="row" fxLayoutAlign="space-between center">
-          <div>{{commission.createdAt.seconds * 1000 | date:'short':null:translate.currentLang}}</div>
+          <div>{{commission.createdAt.seconds * 1000 | date:'short':null:settings.dateFormat}}</div>
           <div [ngSwitch]="commission.status" *ngIf="showStatus">
             <nz-tag *ngSwitchCase="CommissionStatus.OPENED" [style.border-color]="'#108ee9'">{{'COMMISSIONS.STATUS.Label' | translate}}
               : {{'COMMISSIONS.STATUS.OPENED' | translate}}</nz-tag>

--- a/apps/client/src/app/modules/commission-board/commission-panel/commission-panel.component.ts
+++ b/apps/client/src/app/modules/commission-board/commission-panel/commission-panel.component.ts
@@ -9,6 +9,7 @@ import { Observable } from 'rxjs';
 import { CommissionsFacade } from '../+state/commissions.facade';
 import { NotificationType } from '../../../core/notification/notification-type';
 import { map } from 'rxjs/operators';
+import { SettingsService } from '../../settings/settings.service';
 
 @Component({
   selector: 'app-commission-panel',
@@ -33,7 +34,8 @@ export class CommissionPanelComponent implements OnInit {
   public userId$: Observable<string> = this.authFacade.userId$;
 
   constructor(private router: Router, public translate: TranslateService,
-              private authFacade: AuthFacade, public commissionsFacade: CommissionsFacade) {
+              private authFacade: AuthFacade, public commissionsFacade: CommissionsFacade,
+              public settings: SettingsService) {
   }
 
   openCommission(): void {

--- a/apps/client/src/app/modules/commission-board/user-rating-details-popup/user-rating-details-popup.component.html
+++ b/apps/client/src/app/modules/commission-board/user-rating-details-popup/user-rating-details-popup.component.html
@@ -13,13 +13,13 @@
   <div fxLayout="column" fxLayoutAlign="center center" *ngFor="let fired of profile.firedFeedbacks">
     <b><i nz-icon nzType="fire" nzTheme="outline"></i> {{'COMMISSIONS.PROFILE.Fired' | translate}}</b>
     <p>{{('COMMISSIONS.FIRED.' + fired.reason) | translate}}</p>
-    <p>{{fired.date.seconds * 1000 | date:'medium':translate.currentLang}}</p>
+    <p>{{fired.date.seconds * 1000 | date:'medium':null:settings.dateFormat}}</p>
     <a nz-button nzBlock routerLink="/commission/{{fired.commissionId}}" (click)="close()">{{'COMMISSIONS.Open_commission_details' | translate}}</a>
   </div>
   <div fxLayout="column" fxLayoutAlign="center center" *ngFor="let resigned of profile.resignedFeedback">
     <b><i nz-icon nzType="stop" nzTheme="outline"></i> {{'COMMISSIONS.PROFILE.Resigned' | translate}}</b>
     <p>{{('COMMISSIONS.RESIGNED.' + resigned.reason) | translate}}</p>
-    <p>{{resigned.date.seconds * 1000 | date:'medium':translate.currentLang}}</p>
+    <p>{{resigned.date.seconds * 1000 | date:'medium':null:settings.dateFormat}}</p>
     <a nz-button nzBlock routerLink="/commission/{{resigned.commissionId}}" (click)="close()">{{'COMMISSIONS.Open_commission_details' | translate}}</a>
   </div>
 </div>

--- a/apps/client/src/app/modules/commission-board/user-rating-details-popup/user-rating-details-popup.component.ts
+++ b/apps/client/src/app/modules/commission-board/user-rating-details-popup/user-rating-details-popup.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CommissionProfile } from '../../../model/user/commission-profile';
 import { NzModalRef } from 'ng-zorro-antd/modal';
 import { TranslateService } from '@ngx-translate/core';
+import { SettingsService } from '../../settings/settings.service';
 
 @Component({
   selector: 'app-user-rating-details-popup',
@@ -12,7 +13,7 @@ import { TranslateService } from '@ngx-translate/core';
 export class UserRatingDetailsPopupComponent {
   profile: CommissionProfile;
 
-  constructor(private modalRef: NzModalRef, public translate: TranslateService) {
+  constructor(private modalRef: NzModalRef, public translate: TranslateService, public settings: SettingsService) {
   }
 
   close(): void {

--- a/apps/client/src/app/modules/crafting-replay/crafting-replay-row/crafting-replay-row.component.html
+++ b/apps/client/src/app/modules/crafting-replay/crafting-replay-row/crafting-replay-row.component.html
@@ -1,7 +1,7 @@
 <div fxLayout="column" fxLayoutGap="10px">
   <div fxLayout="row wrap" fxLayoutGap="5px" fxLayoutAlign="space-between center">
     <div>
-      {{(replay.startTime.seconds * 1000) | date:'short':translate.currentLang}} - {{replay.itemId | itemName | i18n}} - {{replay.playerStats.craftsmanship}}
+      {{(replay.startTime.seconds * 1000) | date:'short':null:settings.dateFormat}} - {{replay.itemId | itemName | i18n}} - {{replay.playerStats.craftsmanship}}
       /{{replay.playerStats._control}}/{{replay.playerStats.cp}}
     </div>
     <div fxLayout="row wrap" fxLayoutGap="5px">

--- a/apps/client/src/app/modules/crafting-replay/crafting-replay-row/crafting-replay-row.component.ts
+++ b/apps/client/src/app/modules/crafting-replay/crafting-replay-row/crafting-replay-row.component.ts
@@ -7,6 +7,7 @@ import { NzMessageService } from 'ng-zorro-antd/message';
 import { NzModalService } from 'ng-zorro-antd/modal';
 import { PermissionLevel } from '../../../core/database/permissions/permission-level.enum';
 import { PermissionsController } from '../../../core/database/permissions-controller';
+import { SettingsService } from '../../settings/settings.service';
 
 @Component({
   selector: 'app-crafting-replay-row',
@@ -23,7 +24,7 @@ export class CraftingReplayRowComponent {
   userId: string;
 
   constructor(private craftingReplayFacade: CraftingReplayFacade, public translate: TranslateService,
-              private message: NzMessageService, private dialog: NzModalService) {
+              private message: NzMessageService, private dialog: NzModalService, public settings: SettingsService) {
   }
 
   get permissionLevel(): PermissionLevel {

--- a/apps/client/src/app/modules/marketboard/marketboard-popup/marketboard-popup.component.html
+++ b/apps/client/src/app/modules/marketboard/marketboard-popup/marketboard-popup.component.html
@@ -1,7 +1,7 @@
 <nz-alert *ngIf="error; else content" [nzMessage]="'MARKETBOARD.Error' | translate" nzShowIcon
           nzType="error"></nz-alert>
 <ng-template #content>
-  <div *ngIf="lastUpdated$ | async as lastUpdated" class="last-updated"><i>{{'MARKETBOARD.Last_updated' | translate}}: {{lastUpdated | date:'medium'}}</i></div>
+  <div *ngIf="lastUpdated$ | async as lastUpdated" class="last-updated"><i>{{'MARKETBOARD.Last_updated' | translate}}: {{lastUpdated | date:'medium':null:settings.dateFormat}}</i></div>
   <a href="https://universalis.app/market/{{itemId}}"
      target="_blank">{{'MARKETBOARD.More_on_universalis' | translate}}</a>
   <div fxLayout="column" fxLayoutGap="15px">
@@ -41,7 +41,7 @@
         </thead>
         <tbody>
         <tr *ngFor="let row of historyTable.data">
-          <td>{{row.PurchaseDate | date:'short':undefined:getLocale()}}</td>
+          <td>{{row.PurchaseDate | date:'short':undefined:settings.dateFormat}}</td>
           <td>{{row.Quantity}}</td>
           <td *ngIf="!settings.disableCrossWorld">{{row.Server | worldName | i18n}}</td>
           <td><img *ngIf="row.IsHQ" alt="HQ" class="hq-icon" src="./assets/icons/HQ.png"></td>

--- a/apps/client/src/app/modules/player-metrics/display/table/table.component.html
+++ b/apps/client/src/app/modules/player-metrics/display/table/table.component.html
@@ -17,7 +17,7 @@
     <td [nzEllipsis]="true"><div class="item-name" [style.width]="labelWidth | widthBreakpoints">{{row.data[0] | itemName | i18n}}</div></td>
     <td>{{row.data[1] | number:'1.0-0':translate.currentLang}}</td>
     <td *ngIf="showSourceColumn$ | async">{{('METRICS.SOURCES.' + ProbeSource[row.source]) | translate}}</td>
-    <td>{{(row.timestamp * 1000) | date:'medium'}}</td>
+    <td>{{(row.timestamp * 1000) | date:'medium':null:settings.dateFormat}}</td>
     <td><button nz-button nzDanger nzSize="small" nz-popconfirm [nzPopconfirmTitle]="'Confirmation' | translate" (nzOnConfirm)="deleteRow(row.id)"><span nz-icon nzType="delete" nzTheme="outline"></span></button></td>
   </tr>
   </tbody>

--- a/apps/client/src/app/modules/player-metrics/display/table/table.component.ts
+++ b/apps/client/src/app/modules/player-metrics/display/table/table.component.ts
@@ -6,6 +6,7 @@ import { map } from 'rxjs/operators';
 import { IpcService } from '../../../../core/electron/ipc.service';
 import { NzMessageService } from 'ng-zorro-antd/message';
 import { PlayerMetricsService } from '../../player-metrics.service';
+import { SettingsService } from '../../../settings/settings.service';
 
 @Component({
   selector: 'app-table',
@@ -58,7 +59,8 @@ export class TableComponent extends AbstractMetricDisplayComponent implements On
   public sortState: Record<string, string | null> = {};
 
   constructor(public translate: TranslateService, private ipc: IpcService,
-              private message: NzMessageService, private metricsService: PlayerMetricsService) {
+              private message: NzMessageService, private metricsService: PlayerMetricsService,
+              public settings: SettingsService) {
     super();
   }
 

--- a/apps/client/src/app/modules/settings/settings-popup/settings-popup.component.html
+++ b/apps/client/src/app/modules/settings/settings-popup/settings-popup.component.html
@@ -10,6 +10,15 @@
           </nz-select>
         </nz-form-control>
       </nz-form-item>
+      <nz-form-item *ngIf="translate.currentLang==='en'">
+        <nz-form-label [nzSpan]="5">{{'SETTINGS.DateFormat' | translate}}</nz-form-label>
+        <nz-form-control [nzSpan]="12">
+          <nz-select (ngModelChange)="setDateLocale($event)" [ngModel]="settings.dateFormat">
+            <nz-option *ngFor="let locale of availableDateLocales" [nzLabel]="locale | uppercase"
+                       [nzValue]="locale"></nz-option>
+          </nz-select>
+        </nz-form-control>
+      </nz-form-item>
       <nz-form-item>
         <nz-form-label [nzSpan]="5">{{'SETTINGS.Region' | translate}}</nz-form-label>
         <nz-form-control [nzSpan]="12" nzValidateStatus="validating" [nzValidatingTip]="'SETTINGS.Region_explain' | translate">

--- a/apps/client/src/app/modules/settings/settings-popup/settings-popup.component.ts
+++ b/apps/client/src/app/modules/settings/settings-popup/settings-popup.component.ts
@@ -40,6 +40,8 @@ export class SettingsPopupComponent {
 
   availableLanguages = this.settings.availableLocales;
 
+  availableDateLocales = this.settings.availableDateLocales;
+
   availableRegions = this.settings.availableRegions;
 
   loggedIn$ = this.authFacade.loggedIn$;
@@ -480,6 +482,10 @@ export class SettingsPopupComponent {
     localStorage.setItem('locale', lang);
     this.translate.use(lang);
     this.ipc.send('language', lang);
+  }
+
+  setDateLocale(dateLang: string): void {
+    this.settings.dateFormat = dateLang;
   }
 
   saveCustomTheme(): void {

--- a/apps/client/src/app/modules/settings/settings.service.ts
+++ b/apps/client/src/app/modules/settings/settings.service.ts
@@ -7,6 +7,7 @@ import { debounceTime, filter, map, startWith } from 'rxjs/operators';
 import { CommissionTag } from '../commission-board/model/commission-tag';
 import { Language } from '../../core/data/language';
 import { NotificationSettings } from './notification-settings';
+import { TranslateService } from '@ngx-translate/core';
 import { SoundNotificationType } from '../../core/sound-notification/sound-notification-type';
 import { IS_HEADLESS } from '../../../environments/is-headless';
 
@@ -23,7 +24,7 @@ export class SettingsService {
 
   public settingsChange$ = new Subject<string>();
 
-  constructor(@Optional() private ipc: IpcService) {
+  constructor(@Optional() private ipc: IpcService, private translate: TranslateService) {
     this.cache = JSON.parse(localStorage.getItem('settings')) || {};
     if (this.ipc) {
       this.ipc.on('update-settings', (e, settings) => {
@@ -47,6 +48,10 @@ export class SettingsService {
 
   public get availableLocales(): string[] {
     return ['en', 'de', 'fr', 'ja', 'pt', 'br', 'es', 'ko', 'zh', 'ru'];
+  }
+
+  public get availableDateLocales(): string[] {
+    return ['en-US', 'en-GB'];
   }
 
   public get availableRegions(): Region[] {
@@ -140,6 +145,14 @@ export class SettingsService {
 
   public set timeFormat(format: '24H' | '12H') {
     this.setSetting('time-format', format);
+  }
+
+  public get dateFormat(): string {
+    return this.translate.currentLang == "en" ? this.getString('date-format', "en-us") : this.translate.currentLang; 
+  }
+
+  public set dateFormat(lang: string) {
+    this.setString('date-format', lang);
   }
 
   public get listScrollingMode(): 'default' | 'large' | 'never' {

--- a/apps/client/src/app/pages/allagan-reports/allagan-report-row/allagan-report-row.component.html
+++ b/apps/client/src/app/pages/allagan-reports/allagan-report-row/allagan-report-row.component.html
@@ -9,10 +9,10 @@
 
       <div *ngIf="report?.created_at" fxFlex="0 0 auto" fxLayoutAlign="flex-end flex-end" fxFlexAlign="flex-end flex-end"
            class="last-update">{{'ALLAGAN_REPORTS.Last_updated' | translate}}
-        : {{report.created_at | date:'short':translate.currentLang}}</div>
+        : {{report.created_at | date:'short':null:settings.dateFormat}}</div>
       <div *ngIf="queueEntry?.created_at" fxFlex="0 0 auto" fxLayoutAlign="flex-end flex-end" fxFlexAlign="flex-end flex-end"
            class="last-update">{{'ALLAGAN_REPORTS.Submitted' | translate}}
-        : {{queueEntry.created_at | date:'short':translate.currentLang}}</div>
+        : {{queueEntry.created_at | date:'short':null:settings.dateFormat}}</div>
     </div>
     <div fxLayout="row" fxLayoutGap="10px">
       <nz-tag class="custom-tag" *ngIf="status !== AllaganReportStatus.ACCEPTED"

--- a/apps/client/src/app/pages/allagan-reports/allagan-report-row/allagan-report-row.component.ts
+++ b/apps/client/src/app/pages/allagan-reports/allagan-report-row/allagan-report-row.component.ts
@@ -12,6 +12,7 @@ import { observeInput } from '../../../core/rxjs/observe-input';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { SpearfishingShadowSize } from '@ffxiv-teamcraft/types';
 import { SpearfishingSpeed } from '@ffxiv-teamcraft/types';
+import { SettingsService } from '../../../modules/settings/settings.service';
 
 @Component({
   selector: 'app-allagan-report-row',
@@ -83,7 +84,7 @@ export class AllaganReportRowComponent {
     })
   );
 
-  constructor(public translate: TranslateService, private lazyData: LazyDataFacade) {
+  constructor(public translate: TranslateService, private lazyData: LazyDataFacade, public settings: SettingsService) {
   }
 
   @Input()

--- a/apps/client/src/app/pages/commission/commission-details/commission-details.component.html
+++ b/apps/client/src/app/pages/commission/commission-details/commission-details.component.html
@@ -60,7 +60,7 @@
         <div fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="10px">
           <div *ngIf="display.commission.authorId | characterName | async as authorName">
             {{'COMMISSIONS.DETAILS.Created_by' | translate: { name: authorName } }}, {{
-            display.commission.createdAt.seconds * 1000 | date:'medium':null:translate.currentLang}}
+            display.commission.createdAt.seconds * 1000 | date:'medium':null:settings.dateFormat}}
           </div>
           <app-user-rating-display [userId]="display.commission.authorId"></app-user-rating-display>
         </div>
@@ -199,7 +199,7 @@
                 <div>{{display.userOffer.offer | number:'1.0':translate.currentLang}}</div>
               </div>
               <div>
-                {{display.userOffer.date.seconds * 1000 | date:'medium':null:translate.currentLang}}
+                {{display.userOffer.date.seconds * 1000 | date:'medium':null:settings.dateFormat}}
               </div>
               <button nz-button nzDanger nz-popconfirm [nzPopconfirmTitle]="'Confirmation' | translate"
                       (nzOnConfirm)="removeOffer(display.commission, display.userId)">
@@ -299,7 +299,7 @@
               {{'COMMISSIONS.CREATION.Contact_info' | translate}}: <br>{{candidate.contact}}
             </div>
             <div>
-              {{candidate.date.seconds * 1000 | date:'medium':null:translate.currentLang}}
+              {{candidate.date.seconds * 1000 | date:'medium':null:settings.dateFormat}}
             </div>
           </div>
           <div *ngIf="display.commission.candidates.length === 0">

--- a/apps/client/src/app/pages/crafting-replay/crafting-replay/crafting-replay.component.html
+++ b/apps/client/src/app/pages/crafting-replay/crafting-replay/crafting-replay.component.html
@@ -9,7 +9,7 @@
         <div fxLayout="column">
           <div>{{replay.authorId | characterName | async}}</div>
           <div>
-            {{(replay.startTime.seconds * 1000) | date:'short':translate.currentLang}}
+            {{(replay.startTime.seconds * 1000) | date:'short':null:settings.dateFormat}}
             - {{replay.playerStats.craftsmanship}}
             /{{replay.playerStats._control}}/{{replay.playerStats.cp}}
           </div>

--- a/apps/client/src/app/pages/crafting-replay/crafting-replay/crafting-replay.component.ts
+++ b/apps/client/src/app/pages/crafting-replay/crafting-replay/crafting-replay.component.ts
@@ -6,6 +6,7 @@ import { CraftingReplayFacade } from '../../../modules/crafting-replay/+state/cr
 import { CraftingReplay } from '../../../modules/crafting-replay/model/crafting-replay';
 import { Observable } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
+import { SettingsService } from '../../../modules/settings/settings.service';
 
 @Component({
   selector: 'app-crafting-replay',
@@ -18,7 +19,7 @@ export class CraftingReplayComponent extends TeamcraftComponent {
   public replay$: Observable<CraftingReplay> = this.craftingReplayFacade.selectedCraftingReplay$;
 
   constructor(private activeRoute: ActivatedRoute, private craftingReplayFacade: CraftingReplayFacade,
-              public translate: TranslateService) {
+              public translate: TranslateService, public settings: SettingsService) {
     super();
     this.activeRoute.paramMap.pipe(
       takeUntil(this.onDestroy$)

--- a/apps/client/src/app/pages/db/db-comments/db-comments/db-comments.component.html
+++ b/apps/client/src/app/pages/db/db-comments/db-comments/db-comments.component.html
@@ -8,7 +8,7 @@
       <nz-comment *ngIf="comment.$key !== editingComment?.$key; else commentEdition" [nzAuthor]="authorRef"
                   [nzDatetime]="dateRef">
         <ng-template #dateRef>
-          {{comment.date | date:'short':undefined:getLocale()}} ({{getPatch(comment) | async | xivapiI18n}})
+          {{comment.date | date:'short':undefined:settings.dateFormat}} ({{getPatch(comment) | async | xivapiI18n}})
         </ng-template>
         <ng-template #authorRef>
           <div fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">

--- a/apps/client/src/app/pages/db/db-comments/db-comments/db-comments.component.ts
+++ b/apps/client/src/app/pages/db/db-comments/db-comments/db-comments.component.ts
@@ -16,6 +16,7 @@ import { DbCommentReplyNotification } from '../../../../model/notification/db-co
 import { XivapiPatch } from '@ffxiv-teamcraft/types';
 import { LazyDataFacade } from '../../../../lazy-data/+state/lazy-data.facade';
 import { LazyPatchName } from '@ffxiv-teamcraft/data/model/lazy-patch-name';
+import { SettingsService } from '../../../../modules/settings/settings.service';
 
 @Component({
   selector: 'app-db-comments',
@@ -59,7 +60,8 @@ export class DbCommentsComponent extends TeamcraftComponent implements OnInit {
     public translate: TranslateService,
     private router: Router,
     private lazyData: LazyDataFacade,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    public settings: SettingsService
   ) {
     super();
 

--- a/apps/client/src/app/pages/fish-train/fish-train/fish-train.component.html
+++ b/apps/client/src/app/pages/fish-train/fish-train/fish-train.component.html
@@ -107,8 +107,8 @@
             </button>
           </div>
         </nz-page-header-title>
-        <nz-page-header-subtitle>{{'FISH_TRAIN.Departure' | translate:{ time: display.start | date:'short':null:translate.currentLang } }}
-          , {{'FISH_TRAIN.Terminus' | translate:{ time: display.stop | date:'short':null:translate.currentLang } }}</nz-page-header-subtitle>
+        <nz-page-header-subtitle>{{'FISH_TRAIN.Departure' | translate:{ time: display.start | date:'short':null:settings.dateFormat } }}
+          , {{'FISH_TRAIN.Terminus' | translate:{ time: display.stop | date:'short':null:settings.dateFormat } }}</nz-page-header-subtitle>
         <nz-page-header-content>
           <div class="flex-row gap-5">
             <ng-container *ngIf="display.isConductor; else serverTpl">

--- a/apps/client/src/app/pages/fish-train/fish-train/fish-train.component.ts
+++ b/apps/client/src/app/pages/fish-train/fish-train/fish-train.component.ts
@@ -25,6 +25,7 @@ import { LodestoneService } from '../../../core/api/lodestone.service';
 import { TrainFishingReport } from '../../../core/data-reporting/fishing-report';
 import { safeCombineLatest } from '../../../core/rxjs/safe-combine-latest';
 import { PushNotificationsService } from '../../../core/push-notifications.service';
+import { SettingsService } from '../../../modules/settings/settings.service';
 
 @Component({
   selector: 'app-fish-train',
@@ -185,7 +186,7 @@ export class FishTrainComponent extends TeamcraftComponent {
               private authFacade: AuthFacade, private soundNotificationService: SoundNotificationService,
               private notificationService: NzNotificationService, private pushNotificationsService: PushNotificationsService,
               private cd: ChangeDetectorRef, private router: Router, private progressPopup: ProgressPopupService,
-              private lodestone: LodestoneService) {
+              private lodestone: LodestoneService, public settings: SettingsService) {
     super();
     route.paramMap
       .pipe(

--- a/apps/client/src/app/pages/fish-trains/fish-trains/fish-trains.component.html
+++ b/apps/client/src/app/pages/fish-trains/fish-trains/fish-trains.component.html
@@ -64,10 +64,10 @@
       <nz-tag>{{'MARKETBOARD.Server' | translate}}:&nbsp;{{train.world || '???'}}</nz-tag>
     </div>
     <div nz-col [nzXs]="24" [nzSm]="12" [nzMd]="{span: 6, offset: 4}" [nzXl]="{span: 3, offset: 0}">
-      {{'FISH_TRAIN.Departure' | translate: { time: train.start | date:'short':null:translate.currentLang } }}
+      {{'FISH_TRAIN.Departure' | translate: { time: train.start | date:'short':null:settings.dateFormat } }}
     </div>
     <div nz-col [nzXs]="24" [nzSm]="12" [nzMd]="6" [nzXl]="3">
-      {{'FISH_TRAIN.Terminus' | translate: { time: train.end | date:'short':null:translate.currentLang } }}
+      {{'FISH_TRAIN.Terminus' | translate: { time: train.end | date:'short':null:settings.dateFormat } }}
     </div>
     <div nz-col [nzXs]="24" [nzSm]="24" [nzMd]="8" [nzXl]="5">
       <div class="flex-row-wrap justify-end gap-5">

--- a/apps/client/src/app/pages/fish-trains/fish-trains/fish-trains.component.ts
+++ b/apps/client/src/app/pages/fish-trains/fish-trains/fish-trains.component.ts
@@ -10,6 +10,7 @@ import { AuthFacade } from '../../../+state/auth.facade';
 import { TeamcraftComponent } from '../../../core/component/teamcraft-component';
 import { LazyDataFacade } from '../../../lazy-data/+state/lazy-data.facade';
 import { DataModel } from '../../../core/database/storage/data-model';
+import { SettingsService } from '../../../modules/settings/settings.service';
 
 @Component({
   selector: 'app-fish-trains',
@@ -94,7 +95,7 @@ export class FishTrainsComponent extends TeamcraftComponent {
 
   constructor(private fishTrainFacade: FishTrainFacade, public translate: TranslateService,
               private cd: ChangeDetectorRef, private authFacade: AuthFacade,
-              private lazyData: LazyDataFacade) {
+              private lazyData: LazyDataFacade, public settings: SettingsService) {
     super();
     fishTrainFacade.loadAll();
     this.authFacade.mainCharacter$.pipe(

--- a/apps/client/src/app/pages/list-details/list-pricing/list-pricing-row/list-pricing-row.component.html
+++ b/apps/client/src/app/pages/list-details/list-pricing/list-pricing-row/list-pricing-row.component.html
@@ -11,7 +11,7 @@
         : {{priceToCraft.price.nq | number:'1.0-0':translate.currentLang}}</nz-tag>
     </div>
     <div *ngIf="itemPrice.price.updated" fxLayout="row" fxLayoutGap="5px">
-      <nz-tag>{{'PRICING.Last_update' | translate}}: {{itemPrice.price.updated | date:'short':null:translate.currentLang}}</nz-tag>
+      <nz-tag>{{'PRICING.Last_update' | translate}}: {{itemPrice.price.updated | date:'short':null:settings.dateFormat}}</nz-tag>
     </div>
     <div *ngIf="cheapestAtVendor$ | async as cheapestAtVendor" fxLayout="row" fxLayoutGap="5px">
       <button nz-button nzSize="small" nzType="primary"

--- a/apps/client/src/app/pages/list-details/list-pricing/list-pricing-row/list-pricing-row.component.ts
+++ b/apps/client/src/app/pages/list-details/list-pricing/list-pricing-row/list-pricing-row.component.ts
@@ -10,6 +10,7 @@ import { ListPricingService } from '../list-pricing.service';
 import { DataType } from '@ffxiv-teamcraft/types';
 import { TranslateService } from '@ngx-translate/core';
 import { Price } from '../model/price';
+import { SettingsService } from '../../../../modules/settings/settings.service';
 
 @Component({
   selector: 'app-list-pricing-row',
@@ -96,7 +97,7 @@ export class ListPricingRowComponent extends TeamcraftComponent {
   );
 
   constructor(private lazyData: LazyDataFacade, private listPricingService: ListPricingService,
-              public translate: TranslateService) {
+              public translate: TranslateService, public settings: SettingsService) {
     super();
 
     this.updates$.pipe(

--- a/apps/client/src/app/pages/mappy/mappy-dashboard/mappy-dashboard.component.html
+++ b/apps/client/src/app/pages/mappy/mappy-dashboard/mappy-dashboard.component.html
@@ -29,11 +29,11 @@
         <ng-template #description>
           <nz-tag class="custom-tag" [style.border-color]="map.updates?.BNPC && !map.old.BNPC ? '#87d068' : '#f50'">
             <span class="companion-svg">&#x0F202;</span>
-            {{map.updates?.BNPC ? (map.updates?.BNPC * 1000 | date:'medium':null:translate.currentLang) : 'COMMON.Never' | translate}}
+            {{map.updates?.BNPC ? (map.updates?.BNPC * 1000 | date:'medium':null:settings.dateFormat) : 'COMMON.Never' | translate}}
           </nz-tag>
           <nz-tag class="custom-tag" [style.border-color]="map.updates?.Node && !map.old.Node ? '#87d068' : '#f50'">
             <span class="companion-svg">&#x0F016;</span>
-            {{map.updates?.Node ? (map.updates?.Node * 1000 | date:'medium':null:translate.currentLang) : 'COMMON.Never' | translate}}
+            {{map.updates?.Node ? (map.updates?.Node * 1000 | date:'medium':null:settings.dateFormat) : 'COMMON.Never' | translate}}
           </nz-tag>
           <nz-tag [nzColor]="'#f50'" *ngIf="map.missingNodes > 0">{{'MAPPY.X_Missing_nodes' | translate:{ amount: map.missingNodes } }}</nz-tag>
         </ng-template>

--- a/apps/client/src/app/pages/mappy/mappy-dashboard/mappy-dashboard.component.ts
+++ b/apps/client/src/app/pages/mappy/mappy-dashboard/mappy-dashboard.component.ts
@@ -7,6 +7,7 @@ import { map, switchMapTo, tap } from 'rxjs/operators';
 import { subMonths } from 'date-fns';
 import { StaticData } from '../../../lazy-data/static-data';
 import { LazyDataFacade } from '../../../lazy-data/+state/lazy-data.facade';
+import { SettingsService } from '../../../modules/settings/settings.service';
 
 @Component({
   selector: 'app-mappy-dashboard',
@@ -66,7 +67,8 @@ export class MappyDashboardComponent {
   );
 
   constructor(private xivapi: XivapiService,
-              private lazyData: LazyDataFacade, public translate: TranslateService) {
+              private lazyData: LazyDataFacade, public translate: TranslateService,
+              public settigns: SettingsService) {
   }
 
 }

--- a/apps/client/src/app/pages/mappy/mappy/mappy.component.html
+++ b/apps/client/src/app/pages/mappy/mappy/mappy.component.html
@@ -40,9 +40,9 @@
 
     <div fxLayout="column">
       <nz-statistic [nzValue]="display.entries.length" [nzTitle]="'MAPPY.Total_entries' | translate"></nz-statistic>
-      <nz-statistic [nzValue]="display.updates?.BNPC ? (display.updates?.BNPC* 1000 | date:'medium':null:translate.currentLang) : 'COMMON.Never' | translate"
+      <nz-statistic [nzValue]="display.updates?.BNPC ? (display.updates?.BNPC* 1000 | date:'medium':null:settings.dateFormat) : 'COMMON.Never' | translate"
                     [nzTitle]="'MAPPY.Last_bnpc_update' | translate"></nz-statistic>
-      <nz-statistic [nzValue]="display.updates?.Node ? (display.updates?.Node * 1000 | date:'medium':null:translate.currentLang) : 'COMMON.Never' | translate"
+      <nz-statistic [nzValue]="display.updates?.Node ? (display.updates?.Node * 1000 | date:'medium':null:settings.dateFormat) : 'COMMON.Never' | translate"
                     [nzTitle]="'MAPPY.Last_node_update' | translate"></nz-statistic>
 
       <nz-divider nzOrientation="left" nzText="{{'MAPPY.Missing_nodes' | translate}}"></nz-divider>

--- a/apps/client/src/app/pages/profile/public-profile/public-profile.component.html
+++ b/apps/client/src/app/pages/profile/public-profile/public-profile.component.html
@@ -49,7 +49,7 @@
           <ng-template #summary>{{'PROFILE.Total_rankings' | translate}}: #1: {{fishingRankings.summary[1]}}, #2: {{fishingRankings.summary[2]}},
             #3: {{fishingRankings.summary[3]}}</ng-template>
           <cdk-virtual-scroll-viewport itemSize="73" class="fish-rankings-viewport">
-            <nz-list-item *cdkVirtualFor="let row of fishingRankings.data" [nzContent]="row.date | date:'short':undefined:translate.currentLang">
+            <nz-list-item *cdkVirtualFor="let row of fishingRankings.data" [nzContent]="row.date | date:'short':undefined:settings.dateFormat">
               <nz-skeleton *ngIf="!row" [nzAvatar]="true" [nzParagraph]="{ rows: 1 }"></nz-skeleton>
               <nz-list-item-meta [nzAvatar]="avatar"
                                  nzTitle="#{{row.ranking.rank}} - {{row.itemId | itemName | i18n}}"

--- a/apps/client/src/app/pages/profile/public-profile/public-profile.component.ts
+++ b/apps/client/src/app/pages/profile/public-profile/public-profile.component.ts
@@ -15,6 +15,7 @@ import { FirestoreListStorage } from '../../../core/database/storage/list/firest
 import { Apollo } from 'apollo-angular';
 import { TranslateService } from '@ngx-translate/core';
 import * as semver from 'semver';
+import { SettingsService } from '../../../modules/settings/settings.service';
 
 @Component({
   selector: 'app-public-profile',
@@ -42,7 +43,8 @@ export class PublicProfileComponent {
   constructor(private route: ActivatedRoute, private characterService: LodestoneService,
               private listsService: FirestoreListStorage, private authFacade: AuthFacade,
               private userService: UserService, private craftingRotationsService: CraftingRotationService,
-              private apollo: Apollo, public translate: TranslateService) {
+              private apollo: Apollo, public translate: TranslateService,
+              public settings: SettingsService) {
     const userId$ = this.route.paramMap.pipe(
       map(params => params.get('userId')),
       shareReplay({ bufferSize: 1, refCount: true })

--- a/apps/client/src/app/pages/profits-helper/profits-helper/profits-helper.component.html
+++ b/apps/client/src/app/pages/profits-helper/profits-helper/profits-helper.component.html
@@ -1,7 +1,7 @@
 <div fxLayout="row" fxLayoutAlign="space-between center">
   <div>
     <h1>{{'PROFITS.Title' | translate}} - {{server$ | async}}</h1>
-    <p>({{'MAPPY.Last_updated' | translate}}: {{lastUpdated$ | async | date:'medium':null:translate.currentLang}})</p>
+    <p>({{'MAPPY.Last_updated' | translate}}: {{lastUpdated$ | async | date:'medium':null:settings.dateFormat}})</p>
   </div>
   <div>
     <button nz-button nzShape="circle" class="reload-button" nzType="primary" (click)="reloader$.next()" nz-tooltip

--- a/apps/client/src/app/pages/profits-helper/profits-helper/profits-helper.component.ts
+++ b/apps/client/src/app/pages/profits-helper/profits-helper/profits-helper.component.ts
@@ -9,6 +9,7 @@ import { ListRow } from '../../../modules/list/model/list-row';
 import { ProfitEntry } from '../model/profit-entry';
 import { ListPickerService } from '../../../modules/list-picker/list-picker.service';
 import { ListAdditionRecord } from '../../../modules/list-picker/list-addition-record';
+import { SettingsService } from '../../../modules/settings/settings.service';
 
 @Component({
   selector: 'app-profits-helper',
@@ -89,7 +90,8 @@ export class ProfitsHelperComponent {
   itemsInList: Record<number, 1> = {};
 
   constructor(private profitsService: ProfitsService, private authFacade: AuthFacade,
-              public translate: TranslateService, private listPicker: ListPickerService) {
+              public translate: TranslateService, private listPicker: ListPickerService,
+              public settings: SettingsService) {
   }
 
   addItemToList(row: ProfitEntry): void {

--- a/apps/client/src/app/pages/retainers/retainers/retainers.component.html
+++ b/apps/client/src/app/pages/retainers/retainers/retainers.component.html
@@ -21,7 +21,7 @@
           <div fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
             <div>{{row.characterName}}</div>
             <div *ngIf="fetchStatus$ | async as fetchStatus" nz-tooltip
-                 [nzTooltipTitle]="fetchStatus.canFetch ? null : ('RETAINERS.Cannot_fetch' | translate: {date: fetchStatus.lastFetch | date:'medium':null:translate.currentLang})">
+                 [nzTooltipTitle]="fetchStatus.canFetch ? null : ('RETAINERS.Cannot_fetch' | translate: {date: fetchStatus.lastFetch | date:'medium':null:settings.dateFormat})">
               <button nz-button nzShape="circle" nzSize="small" nzType="primary"
                       nz-tooltip [nzTooltipTitle]="fetchStatus.canFetch? ('RETAINERS.Check_prices' | translate) : null"
                       [disabled]="!fetchStatus.canFetch || row.server === 'Unknown'"

--- a/apps/client/src/app/pages/teams-pages/teams/teams.component.html
+++ b/apps/client/src/app/pages/teams-pages/teams/teams.component.html
@@ -80,7 +80,7 @@
                         </button>
                         <div class="spacer"></div>
                         <div>{{'TEAMS.Invite_expires' | translate}}: {{invite.expires === undefined ? ('Never' |
-                          translate) : invite.expires | date:'short'}}
+                          translate) : invite.expires | date:'short':null:settings.dateFormat}}
                         </div>
                         <button (click)="$event.stopPropagation()" (nzOnConfirm)="deleteInvite(invite)" [nzShape]="'circle'" [nzPopconfirmTitle]="'Confirmation' | translate"
                                 nzDanger nz-button

--- a/apps/client/src/app/pages/teams-pages/teams/teams.component.ts
+++ b/apps/client/src/app/pages/teams-pages/teams/teams.component.ts
@@ -16,6 +16,7 @@ import { PlatformService } from '../../../core/tools/platform.service';
 import { IpcService } from '../../../core/electron/ipc.service';
 import { WebhookSetting } from '../../../model/team/webhook-setting';
 import { OauthService } from '../../../core/auth/oauth.service';
+import { SettingsService } from '../../../modules/settings/settings.service';
 
 @Component({
   selector: 'app-teams',
@@ -43,7 +44,8 @@ export class TeamsComponent implements OnInit {
               private authFacade: AuthFacade, private discordWebhook: DiscordWebhookService,
               private message: NzMessageService, private route: ActivatedRoute, private router: Router,
               private http: HttpClient, private platform: PlatformService,
-              private ipc: IpcService, private oauth: OauthService) {
+              private ipc: IpcService, private oauth: OauthService,
+              public settings: SettingsService) {
     this.teamsFacade.loadMyTeams();
   }
 

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-row.component.html
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-row.component.html
@@ -4,7 +4,7 @@
   </div>
   <div fxFlex="0 0 20%" fxLayoutAlign="center center">
     <ng-container *ngIf="vessel?.returnTime > 0; else noReturnTime">
-      {{ vessel?.returnTime * 1000 | date:'short':null:translate.currentLang }}
+      {{ vessel?.returnTime * 1000 | date:'short':null:settings.dateFormat }}
     </ng-container>
     <ng-template #noReturnTime>
       -

--- a/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-row.component.ts
+++ b/apps/client/src/app/pages/voyage-tracker/voyage-tracker/vessel-row/vessel-row.component.ts
@@ -2,11 +2,13 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { Vessel } from '../../../../modules/free-company-workshops/model/vessel';
 import { TeamcraftComponent } from '../../../../core/component/teamcraft-component';
 import { TranslateService } from '@ngx-translate/core';
+import { SettingsService } from '../../../../modules/settings/settings.service';
 import { FreeCompanyWorkshopFacade } from '../../../../modules/free-company-workshops/+state/free-company-workshop.facade';
 import { Submarine } from '../../../../modules/free-company-workshops/model/submarine';
 import { timer } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
 import { Airship } from '../../../../modules/free-company-workshops/model/airship';
+
 
 @Component({
   selector: 'app-vessel-row',
@@ -26,7 +28,7 @@ export class VesselRowComponent extends TeamcraftComponent {
     takeUntil(this.onDestroy$)
   );
 
-  constructor(private freeCompanyWorkshopFacade: FreeCompanyWorkshopFacade, public translate: TranslateService) {
+  constructor(private freeCompanyWorkshopFacade: FreeCompanyWorkshopFacade, public translate: TranslateService, public settings: SettingsService) {
     super();
   }
 

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -424,6 +424,7 @@
     "Title": "Settings",
     "General": "General",
     "Link_base": "Item links",
+    "DateFormat": "Date Format",
     "Region": "Region",
     "Region_explain": "Data source and functions based on specific game version will be adjusted per region. Some of them may not be available in certain regions.",
     "Proxy": "Proxy",


### PR DESCRIPTION
By default, users that use the `EN` locale are forced to use the middle-endian date format due to Unicode subtagging `en-us` to the `en` format. This PR changes the behaviour so when a user has their app locale set to `EN` they are presented with an additional drop-down allowing them to specify the date format they wish to use. Currently only `EN-US` and `EN-GB` are implemented as they seem to be the two most relevant formats.
![image](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/assets/12771982/56851b9a-715b-43eb-9533-b92ba3b5a444)
When a non-english langauge is used, the date format is directed to the current user's locale and the dropdown box is hidden.

Before:
![image](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/assets/12771982/01dbfa7f-0791-42f8-b403-0fe204136f56)

After:
![image](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/assets/12771982/fda64a40-0964-4d02-9478-d7b39a0240a2)
*of note, en-gb uses 24hr time*

Fixes a complaint discussed on Discord

A number of changes to the components here haven't been properly tested due [not logging in to the developer environment](https://canary.discord.com/channels/355013337748209665/462954987329159176/1163727050130067549), which if there are any issues/missed files will cause components not to render