### PR TITLE
feat(layouts): Add CAN_BE_BOUGHT_WITHOUT_TRIBES layout filter

### DIFF
--- a/apps/client/src/app/core/layout/layout-row-filter.ts
+++ b/apps/client/src/app/core/layout/layout-row-filter.ts
@@ -36,6 +36,10 @@ export class LayoutRowFilter {
     return vendors.length > 0;
   }, 'CAN_BE_BOUGHT', [DataType.VENDORS]);
 
+  static CAN_BE_BOUGHT_WITHOUT_TRIBES = this.CAN_BE_BOUGHT._and(new LayoutRowFilter((row) => {
+    return getItemSource(row, DataType.VENDORS).some(vendor => !beastTribeNpcs.includes(vendor.npcId));
+  }, 'CAN_BE_BOUGHT_WITHOUT_TRIBES', [DataType.VENDORS]));
+
   static IS_FROM_HOUSING_VENDOR = new LayoutRowFilter((row, _, settings) => {
     let vendors = getItemSource<Vendor[]>(row, DataType.VENDORS).filter(s => {
       return housingMaterialSuppliers.includes(s.npcId);


### PR DESCRIPTION
I added this filter because the solution in #2479 doesn't work properly, since some items can be bought from tribe vendors as well as normal vendors.

CAN_BE_BOUGHT AND NOT FROM_BEAST_TRIBE:
![image](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/assets/28735963/c29acd0a-b7cb-4a68-82f2-8d491074c7d2)
CAN_BE_BOUGHT_WITHOUT_TRIBES:
![image](https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/assets/28735963/0246f2fa-41a0-4e2c-a389-231391b72fab)
