### PR TITLE
chore(Debugging): Add vscode config settings for debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,21 @@
+// Based off https://github.com/Microsoft/vscode-recipes/tree/master/Angular-CLI
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
-  "configurations": [{
-    "name": "Launch Edge",
-    "type": "edge",
-    "request": "launch",
-    "version": "beta",
-    "url": "http://localhost:4200",
-    "webRoot": "${workspaceFolder}/apps/client"
-  }]
+  "configurations": [
+    {
+      "name": "Launch Edge",
+      "type": "msedge",
+      "request": "launch",
+      "preLaunchTask": "npm: start",
+      "url": "http://localhost:4200/#",
+      "webRoot": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "webpack:/*": "${webRoot}/*",
+        "/./*": "${webRoot}/*",
+        "/src/*": "${webRoot}/*",
+        "/*": "*",
+        "/./~/*": "${webRoot}/node_modules/*"
+      }
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,20 @@
 {
-    "editor.tabSize": 2
+    "editor.tabSize": 2,
+
+    // Debugging requires Powershell to execute yarn commands.
+    // By default, Powershell disables execution of scripts.
+    // To allow yarn, we include this workspace-specific configuration
+    // to allow execution of remote signed scripts
+    // https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.4#powershell-execution-policies
+    "terminal.integrated.profiles.windows": {
+        "PowerShell": {
+            "source": "PowerShell",
+            "icon": "terminal-powershell",
+            "args": [
+                "-ExecutionPolicy",
+                "RemoteSigned"
+            ]
+        }
+    },
+    "terminal.integrated.defaultProfile.windows": "PowerShell",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,7 +32,7 @@
             // Regex to look for in the terminal output to determine when the background process
             // has completed and the foreground browser launching process can proceed.
             // This may need to be updated if messaging changes or unaccounted messages appear.
-            "regexp": "Application bundle generation complete. |Failed to compile. |terminated with exit code: 1"
+            "regexp": "Application bundle generation complete.|Failed tasks:|terminated with exit code: 1"
           }
         }
       }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,13 +1,41 @@
+// Based off https://github.com/Microsoft/vscode-recipes/tree/master/Angular-CLI
 {
-  // See https://go.microsoft.com/fwlink/?LinkId=733558
-  // for the documentation about the tasks.json format
   "version": "2.0.0",
-  "tasks": [{
-    "label": "npm start",
-    "type": "npm",
-    "script": "start",
-    "problemMatcher": [
-      "$tsc"
-    ]
-  }]
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "start",
+      "isBackground": true,
+      "presentation": {
+        "focus": true,
+        "panel": "dedicated"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": {
+        "owner": "typescript",
+        "source": "ts",
+        "applyTo": "closedDocuments",
+        "fileLocation": [
+          "relative",
+          "${cwd}"
+        ],
+        "pattern": "$tsc",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": {
+            "regexp": "(.*?)"
+          },
+          "endsPattern": {
+            // Regex to look for in the terminal output to determine when the background process
+            // has completed and the foreground browser launching process can proceed.
+            // This may need to be updated if messaging changes or unaccounted messages appear.
+            "regexp": "Application bundle generation complete. |Failed to compile. |terminated with exit code: 1"
+          }
+        }
+      }
+    },
+  ]
 }


### PR DESCRIPTION
Updates the .vscode/ config files to support out-of-the-box debugging with breakpoints. After following the prerequisite steps outlined in https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/blob/staging/CONTRIBUTING.md, users can run the "Launch edge" configuration which will serve a debuggable application and open an edge browser

Emphasis on "with breakpoints". I'm sure this is trivial to people who are familiar with TS and Angular, but as someone who has never worked with it, getting to this point took more time than I'd like to admit. I'm hoping having these settings in the repo will lower the entry barrier to others looking to contribute.