### PR TITLE
Ensure termination of preLaunchTask in "Launch Edge" vscode config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,8 @@
       "name": "Launch Edge",
       "type": "msedge",
       "request": "launch",
-      "preLaunchTask": "npm: start",
+      "preLaunchTask": "Live Development Server",
+      "postDebugTask": "Terminate Live Development Server",
       "url": "http://localhost:4200/#",
       "webRoot": "${workspaceFolder}",
       "sourceMapPathOverrides": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,6 +3,8 @@
   "version": "2.0.0",
   "tasks": [
     {
+      // Task to start the Live Development Server
+      "label": "Live Development Server",
       "type": "npm",
       "script": "start",
       "isBackground": true,
@@ -37,5 +39,19 @@
         }
       }
     },
-  ]
+    {
+      // Task to terminate the Live Development Server
+      "label": "Terminate Live Development Server",
+      "command": "echo ${input:termianteLiveDevelopmentServer}",
+      "type": "shell",
+    },
+  ],
+  "inputs": [
+    {
+      "id": "termianteLiveDevelopmentServer",
+      "type": "command",
+      "command": "workbench.action.tasks.terminate",
+      "args": "Live Development Server" // The task label to terminate
+    },
+  ],
 }


### PR DESCRIPTION
If you focus off the console window (by navigating to another one) that the preLaunchTask launches and then end the debugging session, the console window does not close

This PR adds a postDebugTask (essentially the opposite of "preLaunchTask") that ensures the preLaunchTask console window is closed