### PR TITLE
chore(Debugging): VSCode Configuration for Main electron process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,22 @@
         "/*": "*",
         "/./~/*": "${webRoot}/node_modules/*"
       }
-    }
+    },
+    {
+      // A configuration based on the time-of-writing's CONTRIBUTING.md
+      // NOTE: Some changes that are picked up by --watch flag can be reflected
+      // in the electron app simply by refreshing the app (CTRL-R)
+      "name": "Electron: Main",
+      "type": "node",
+      "request": "launch",
+      "preLaunchTask": "Build and Watch",
+      "postDebugTask": "Terminate 'Build and Watch'",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [
+        "electron:start"
+      ],
+      "outputCapture": "std",
+    },
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -45,6 +45,49 @@
       "command": "echo ${input:termianteLiveDevelopmentServer}",
       "type": "shell",
     },
+    {
+      // Task to Build and Watch
+      "label": "Build and Watch",
+      "type": "npm",
+      "script": "build:watch",
+      "isBackground": true,
+      "presentation": {
+        "focus": true,
+        "panel": "dedicated"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": {
+        "owner": "typescript",
+        "source": "ts",
+        "applyTo": "closedDocuments",
+        "fileLocation": [
+          "relative",
+          "${cwd}"
+        ],
+        "pattern": "$tsc",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": {
+            "regexp": "(.*?)"
+          },
+          "endsPattern": {
+            // Regex to look for in the terminal output to determine when the background process
+            // has completed and the foreground browser launching process can proceed.
+            // This may need to be updated if messaging changes or unaccounted messages appear.
+            "regexp": "Watch mode enabled. Watching for file changes...|Failed tasks:|terminated with exit code: 1"
+          }
+        }
+      }
+    },
+    {
+      // Task to terminate the 'Build and Watch' task
+      "label": "Terminate 'Build and Watch'",
+      "command": "echo ${input:termianteBuildAndWatch}",
+      "type": "shell",
+    },
   ],
   "inputs": [
     {
@@ -52,6 +95,12 @@
       "type": "command",
       "command": "workbench.action.tasks.terminate",
       "args": "Live Development Server" // The task label to terminate
+    },
+    {
+      "id": "termianteBuildAndWatch",
+      "type": "command",
+      "command": "workbench.action.tasks.terminate",
+      "args": "Build and Watch" // The task label to terminate
     },
   ],
 }


### PR DESCRIPTION
Defines a VSCode configuration for launching a Teamcraft desktop app. The configuration follows the steps outlined in https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/blob/staging/CONTRIBUTING.md#the-desktop-app

The configuration starts the `build:watch` package.json script in a dedicated terminal. Once that has finished building and starts watching for file changes, the `electron:start` package.json script is ran and launches the Teamcraft app. The `build:watch` script continues to run until the configuration is terminated (ie user closes Teamcraft app or explicitly stops the debugging session)

For changes that are picked up by the --watch flag and trigger new dist files to be generated, simply refreshing the app via CTRL-R will reflect the changes in the app and an entire re-run of the configuration is not needed

This PR **DOES NOT** add support for debugging the Electron Renderer process. For that, see #2828