### PR TITLE
fix(desktop): Correct build of dll-inject to avoid AV issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "dexie": "^3.2.3",
     "echarts": "^5.5.0",
     "electron": "^31.2.0",
-    "electron-builder": "^25.0.0",
+    "electron-builder": "^25.1.8",
     "electron-builder-squirrel-windows": "^25.0.0",
     "enquirer": "^2.3.6",
     "eslint": "8.48.0",


### PR DESCRIPTION
Update the version of electon-build to stop generating Debug versions. This generates a Release version of dll-inject which doesn't trigger the AV programs.

electron-userland/electron-builder#8531