### PR TITLE
fix(pcap): load deucalion with correct version for KR

### DIFF
--- a/apps/electron/src/pcap/packet-capture.ts
+++ b/apps/electron/src/pcap/packet-capture.ts
@@ -188,7 +188,7 @@ export class PacketCapture {
           log.info('[pcap] Using localOpcodes:', localDataPath);
         }
       } else {
-        options.deucalionDllPath = join(app.getAppPath(), '../../deucalion/deucalion.dll');
+        options.deucalionDllPath = region === 'KR' ? join(app.getAppPath(), '../../deucalion/deucalion_12.dll') : join(app.getAppPath(), '../../deucalion/deucalion.dll');
       }
 
       log.info(`Starting PacketCapture with options: ${JSON.stringify(options)}`);


### PR DESCRIPTION
I'll leave this part as is until the Korean and global versions are fully synchronized, even if the major versions are the same.

And the new version of [pcap](https://github.com/ffxiv-teamcraft/pcap-ffxiv/pull/44) is also needed.