### PR TITLE
fix(simulator/ux): rename custom sim button

### DIFF
--- a/apps/client/src/app/pages/simulator/components/recipe-choice-popup/recipe-choice-popup.component.html
+++ b/apps/client/src/app/pages/simulator/components/recipe-choice-popup/recipe-choice-popup.component.html
@@ -52,7 +52,7 @@
     <nz-divider [nzText]="'Or' | translate"></nz-divider>
     <a (click)="close()" class="new-list-button" nz-button nzBlock
       routerLink="/simulator/custom/{{rotationId}}" [queryParams]="statsStr?{stats: statsStr}:null">
-      {{'SIMULATOR.Create_a_custom_rotation' | translate}}
+      {{'SIMULATOR.Custom_recipe_simulation' | translate}}
     </a>
   </div>
 }

--- a/apps/client/src/assets/i18n/de-DE.json
+++ b/apps/client/src/assets/i18n/de-DE.json
@@ -1110,7 +1110,7 @@
     "Rotations": "Handwerks Rotationen",
     "Favorite_Rotations": "Favorisierte Rotationen",
     "No_rotations": "Keine Rotationen",
-    "Create_a_custom_rotation": "Erstelle eine benutzerdefinierte Rotation",
+    "Custom_recipe_simulation": "Simulation mit benutzerdefinierten Rezeptwerten (fortgeschritten)",
     "Reset": "Rotation zurücksetzen",
     "Reset_saved": "Ungespeicherte Änderungen zurücksetzen",
     "Import_from_crafting_optimizer": "Von Handwerks Optimierung importieren",

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -1110,7 +1110,7 @@
     "Rotations": "Crafting rotations",
     "Favorite_Rotations": "Favorite Rotations",
     "No_rotations": "No rotations",
-    "Create_a_custom_rotation": "Create a custom rotation",
+    "Custom_recipe_simulation": "Simulate using custom recipe values (advanced)",
     "Reset": "Reset rotation",
     "Reset_saved": "Revert unsaved changes",
     "Import_from_crafting_optimizer": "Import from crafting optimizer",

--- a/apps/client/src/assets/i18n/es-ES.json
+++ b/apps/client/src/assets/i18n/es-ES.json
@@ -1110,7 +1110,7 @@
     "Rotations": "Rotaciones de artesanías",
     "Favorite_Rotations": "Rotaciones Favoritas",
     "No_rotations": "No hay rotaciones",
-    "Create_a_custom_rotation": "Crear rotación personalizada",
+    "Custom_recipe_simulation": "Simular el uso de valores de recetas personalizados (avanzado)",
     "Reset": "Reiniciar rotación",
     "Reset_saved": "Revertir cambios no guardados",
     "Import_from_crafting_optimizer": "Importar desde optimizador de artesanía",

--- a/apps/client/src/assets/i18n/fr-FR.json
+++ b/apps/client/src/assets/i18n/fr-FR.json
@@ -1110,7 +1110,7 @@
     "Rotations": "Rotations de craft",
     "Favorite_Rotations": "Rotations préférées",
     "No_rotations": "Aucune rotation",
-    "Create_a_custom_rotation": "Créer une rotation personnalisée",
+    "Custom_recipe_simulation": "Simulation à l'aide de valeurs de recette personnalisées (avancé)",
     "Reset": "Remettre à zéro la rotation",
     "Reset_saved": "Annuler les modifications non enregistrées",
     "Import_from_crafting_optimizer": "Importer depuis crafting optimizer",

--- a/apps/client/src/assets/i18n/hr-HR.json
+++ b/apps/client/src/assets/i18n/hr-HR.json
@@ -1110,7 +1110,7 @@
     "Rotations": "Crafting rotations",
     "Favorite_Rotations": "Favorite Rotations",
     "No_rotations": "No rotations",
-    "Create_a_custom_rotation": "Create a custom rotation",
+    "Custom_recipe_simulation": "Simulate using custom recipe values (advanced)",
     "Reset": "Reset rotation",
     "Reset_saved": "Revert unsaved changes",
     "Import_from_crafting_optimizer": "Import from crafting optimizer",

--- a/apps/client/src/assets/i18n/ja-JP.json
+++ b/apps/client/src/assets/i18n/ja-JP.json
@@ -1110,7 +1110,7 @@
     "Rotations": "スキル回し",
     "Favorite_Rotations": "制作スキル回しお気に入り",
     "No_rotations": "スキル回しがありません",
-    "Create_a_custom_rotation": "カスタムでスキル回しを作成する",
+    "Custom_recipe_simulation": "カスタムレシピ値を使用してシミュレーションする（上級）",
     "Reset": "リセット",
     "Reset_saved": "未保存の変更を元に戻す",
     "Import_from_crafting_optimizer": "Crafting optimizerから取り込む",

--- a/apps/client/src/assets/i18n/ko-KR.json
+++ b/apps/client/src/assets/i18n/ko-KR.json
@@ -1110,7 +1110,7 @@
     "Rotations": "제작 로테이션",
     "Favorite_Rotations": "로테이션 즐겨찾기",
     "No_rotations": "등록된 로테이션이 없습니다",
-    "Create_a_custom_rotation": "사용자 지정 로테이션 만들기",
+    "Custom_recipe_simulation": "사용자 지정 레시피 값을 사용하여 시뮬레이션(고급)",
     "Reset": "로테이션 초기화",
     "Reset_saved": "저장하지 않은 변경사항 되돌리기",
     "Import_from_crafting_optimizer": "Crafting optimizer 에서 가져오기",

--- a/apps/client/src/assets/i18n/nl-NL.json
+++ b/apps/client/src/assets/i18n/nl-NL.json
@@ -1110,7 +1110,7 @@
     "Rotations": "Crafting rotations",
     "Favorite_Rotations": "Favorite Rotations",
     "No_rotations": "No rotations",
-    "Create_a_custom_rotation": "Create a custom rotation",
+    "Custom_recipe_simulation": "Simulate using custom recipe values (advanced)",
     "Reset": "Reset rotation",
     "Reset_saved": "Revert unsaved changes",
     "Import_from_crafting_optimizer": "Import from crafting optimizer",

--- a/apps/client/src/assets/i18n/pt-BR.json
+++ b/apps/client/src/assets/i18n/pt-BR.json
@@ -1110,7 +1110,7 @@
     "Rotations": "Rotações de Craft",
     "Favorite_Rotations": "Rotações favoritas",
     "No_rotations": "Sem rotação",
-    "Create_a_custom_rotation": "Criar uma rotação personalizada",
+    "Custom_recipe_simulation": "Simular usando valores de receita personalizados (avançado)",
     "Reset": "Redefinir rotação",
     "Reset_saved": "Reverter alterações não salvas",
     "Import_from_crafting_optimizer": "Importar para o otimizador de craft",

--- a/apps/client/src/assets/i18n/pt-PT.json
+++ b/apps/client/src/assets/i18n/pt-PT.json
@@ -1110,7 +1110,7 @@
     "Rotations": "Sequências de criação",
     "Favorite_Rotations": "Sequências favoritas",
     "No_rotations": "Sem sequências",
-    "Create_a_custom_rotation": "Create a custom rotation",
+    "Custom_recipe_simulation": "Simulate using custom recipe values (advanced)",
     "Reset": "Redefinir sequência",
     "Reset_saved": "Revert unsaved changes",
     "Import_from_crafting_optimizer": "Import from crafting optimizer",

--- a/apps/client/src/assets/i18n/ru-RU.json
+++ b/apps/client/src/assets/i18n/ru-RU.json
@@ -1110,7 +1110,7 @@
     "Rotations": "Крафтовая ротация",
     "Favorite_Rotations": "Избранная ротация",
     "No_rotations": "Нет ротаций",
-    "Create_a_custom_rotation": "Создать кастомную ротацию",
+    "Custom_recipe_simulation": "Моделирование с использованием пользовательских значений рецепта (расширенные настройки)",
     "Reset": "Сбросить ротацию",
     "Reset_saved": "Восстановить несохраненные изменения",
     "Import_from_crafting_optimizer": "Импортировать из crafting optimizer",

--- a/apps/client/src/assets/i18n/zh-CN.json
+++ b/apps/client/src/assets/i18n/zh-CN.json
@@ -1110,7 +1110,7 @@
     "Rotations": "生产手法",
     "Favorite_Rotations": "收藏手法",
     "No_rotations": "无手法",
-    "Create_a_custom_rotation": "创建自定义手法",
+    "Custom_recipe_simulation": "使用自定义配方值进行模拟（高级）",
     "Reset": "重置手法",
     "Reset_saved": "撤销未保存的改动",
     "Import_from_crafting_optimizer": "从制作模拟器导入",

--- a/apps/client/src/assets/i18n/zh-TW.json
+++ b/apps/client/src/assets/i18n/zh-TW.json
@@ -1110,7 +1110,7 @@
     "Rotations": "生產工序",
     "Favorite_Rotations": "收藏工序",
     "No_rotations": "無工序",
-    "Create_a_custom_rotation": "建立自訂工序",
+    "Custom_recipe_simulation": "使用自訂配方值進行模擬（高級）",
     "Reset": "重置工序",
     "Reset_saved": "還原未儲存的變更",
     "Import_from_crafting_optimizer": "從生產優化器匯入",


### PR DESCRIPTION
Renaming the button link to the custom recipe simulator as it was misleading at times.

Resolves #3109