### PR TITLE
feat: use TW version's data in search and db pages

### DIFF
--- a/apps/client/src/app/core/tools/normalize-i18n.ts
+++ b/apps/client/src/app/core/tools/normalize-i18n.ts
@@ -1,7 +1,7 @@
 import { I18nName, XivapiI18nName } from '@ffxiv-teamcraft/types';
 
 export function normalizeI18nName(row: I18nName | { name: I18nName } | XivapiI18nName): I18nName {
-  if ((row as I18nName).en !== undefined || (row as I18nName).zh !== undefined || (row as I18nName).ko !== undefined) {
+  if ((row as I18nName).en !== undefined || (row as I18nName).zh !== undefined || (row as I18nName).ko !== undefined || (row as I18nName).tw !== undefined) {
     return row as I18nName;
   }
   if ((row as { name: I18nName }).name) {

--- a/apps/client/src/app/lazy-data/+state/lazy-data.facade.ts
+++ b/apps/client/src/app/lazy-data/+state/lazy-data.facade.ts
@@ -75,14 +75,15 @@ export class LazyDataFacade {
             const global$ = of(this.merge(entry));
             const cn$ = this.getEntry(this.findPrefixedProperty(propertyKey, 'zh'));
             const kr$ = this.getEntry(this.findPrefixedProperty(propertyKey, 'ko'));
+            const tw$ = this.getEntry(this.findPrefixedProperty(propertyKey, 'tw'));
 
             if (forceAll) {
               return combineLatest([
                 global$,
-                cn$, kr$
+                cn$, kr$, tw$
               ]).pipe(
-                map(([global, cn, kr]) => {
-                  return this.merge(global, cn, kr);
+                map(([global, cn, kr, tw]) => {
+                  return this.merge(global, cn, kr, tw);
                 })
               );
             }
@@ -101,6 +102,12 @@ export class LazyDataFacade {
                 return kr$.pipe(
                   map(koRow => {
                     return this.merge(entry, koRow);
+                  })
+                );
+              case Region.Taiwan:
+                return tw$.pipe(
+                  map(twRow => {
+                    return this.merge(entry, twRow);
                   })
                 );
             }
@@ -155,6 +162,9 @@ export class LazyDataFacade {
             if (this.translate.currentLang === 'zh') {
               region = Region.China;
             }
+            if (this.translate.currentLang === 'tw') {
+              region = Region.Taiwan;
+            }
             switch (region) {
               case Region.Global:
                 return of(row);
@@ -179,6 +189,18 @@ export class LazyDataFacade {
                     return {
                       ...row,
                       ...normalizeI18nName(extendedProperty ? row[extendedProperty as string] : koRow)
+                    };
+                  })
+                );
+              case Region.Taiwan:
+                return this.getRow(this.findPrefixedProperty(propertyKey, 'tw') as LazyDataRecordKey, id).pipe(
+                  map(twRow => {
+                    if (twRow === null) {
+                      return row;
+                    }
+                    return {
+                      ...row,
+                      ...normalizeI18nName(extendedProperty ? row[extendedProperty as string] : twRow)
                     };
                   })
                 );
@@ -221,7 +243,8 @@ export class LazyDataFacade {
       de: world,
       ja: world,
       zh: zhWorlds[world] ?? world,
-      ko: koWorlds[world] ?? world
+      ko: koWorlds[world] ?? world,
+      tw: world
     };
   }
 

--- a/apps/data-extraction/src/abstract-extractor.ts
+++ b/apps/data-extraction/src/abstract-extractor.ts
@@ -8,7 +8,7 @@ import { XivDataService } from './xiv/xiv-data.service';
 import { ParsedRow } from './xiv/parsed-row';
 import { LazyData } from '@ffxiv-teamcraft/data/model/lazy-data';
 import { kebabCase } from 'lodash';
-import { I18nName, LazyDataChineseKey, LazyDataI18nKey, LazyDataKoreanKey } from '@ffxiv-teamcraft/types';
+import { I18nName, LazyDataChineseKey, LazyDataI18nKey, LazyDataKoreanKey, LazyDataTraditionalChineseKey } from '@ffxiv-teamcraft/types';
 import zlib from 'zlib';
 import { LazyPatchContent } from '@ffxiv-teamcraft/data/model/lazy-patch-content';
 
@@ -90,6 +90,9 @@ export abstract class AbstractExtractor {
     }
     if (kebab.startsWith('zh-')) {
       path = join(AbstractExtractor.assetOutputFolder, 'zh', `${kebabCase(key)}.json`);
+    }
+    if (kebab.startsWith('tw-')) {
+      path = join(AbstractExtractor.assetOutputFolder, 'tw', `${kebabCase(key)}.json`);
     }
     return JSON.parse(readFileSync(path, 'utf-8'));
   }
@@ -303,7 +306,7 @@ export abstract class AbstractExtractor {
     return cleaned;
   }
 
-  private findPrefixedProperty(property: LazyDataI18nKey, prefix: 'ko' | 'zh'): LazyDataI18nKey {
+  private findPrefixedProperty(property: LazyDataI18nKey, prefix: 'ko' | 'zh' | 'tw'): LazyDataI18nKey {
     return `${prefix}${property[0].toUpperCase()}${property.slice(1)}` as unknown as LazyDataI18nKey;
   }
 
@@ -313,6 +316,7 @@ export abstract class AbstractExtractor {
     const baseEntry = this.requireLazyFileByKey(property);
     const koEntries = this.requireLazyFileByKey(this.findPrefixedProperty(property, 'ko'));
     const zhEntries = this.requireLazyFileByKey(this.findPrefixedProperty(property, 'zh'));
+    const twEntries = this.requireLazyFileByKey(this.findPrefixedProperty(property, 'tw'));
     return Object.entries<T>(baseEntry as any)
       .filter(([, entry]) => getNameFn(entry).en?.length > 0)
       .map(([id, entry]) => {
@@ -328,6 +332,9 @@ export abstract class AbstractExtractor {
         if (zhEntries[id]) {
           row.zh = zhEntries[id].zh;
         }
+        if (twEntries[id]) {
+          row.tw = twEntries[id].tw;
+        }
         return row;
       });
   }
@@ -336,13 +343,15 @@ export abstract class AbstractExtractor {
     field: string,
     targetField?: string,
     koSource?: LazyDataKoreanKey,
-    zhSource?: LazyDataChineseKey
+    zhSource?: LazyDataChineseKey,
+    twSource?: LazyDataTraditionalChineseKey
   }[]): { row: any, extended: any }[] {
     const preloadedAsianSources = {};
     sources.forEach(source => {
       preloadedAsianSources[source.field] = {
         ko: source.koSource ? this.requireLazyFileByKey(source.koSource) : null,
-        zh: source.zhSource ? this.requireLazyFileByKey(source.zhSource) : null
+        zh: source.zhSource ? this.requireLazyFileByKey(source.zhSource) : null,
+        tw: source.twSource ? this.requireLazyFileByKey(source.twSource) : null
       };
     });
     return data
@@ -355,6 +364,7 @@ export abstract class AbstractExtractor {
           const target = targetField ? extended[targetField] : extended;
           const ko = preloadedAsianSources[field]?.['ko']?.[row.index];
           const zh = preloadedAsianSources[field]?.['zh']?.[row.index];
+          const tw = preloadedAsianSources[field]?.['tw']?.[row.index];
 
           target.en = row[`${field}_en`];
           target.de = row[`${field}_de`];
@@ -365,6 +375,9 @@ export abstract class AbstractExtractor {
           }
           if (zh) {
             target.zh = zh.zh;
+          }
+          if (tw) {
+            target.tw = tw.tw;
           }
         });
         return { row, extended };

--- a/apps/data-extraction/src/extractors/db/achievements-db-pages.extractor.ts
+++ b/apps/data-extraction/src/extractors/db/achievements-db-pages.extractor.ts
@@ -9,12 +9,14 @@ export class AchievementsDbPagesExtractor extends AbstractExtractor {
           {
             field: 'Name',
             koSource: 'koAchievements',
-            zhSource: 'zhAchievements'
+            zhSource: 'zhAchievements',
+            twSource: 'twAchievements'
           },
           {
             field: 'Description',
             koSource: 'koAchievementDescriptions',
             zhSource: 'zhAchievementDescriptions',
+            twSource: 'twAchievementDescriptions',
             targetField: 'description'
           }
         ]).reduce((acc, { row, extended }) => {

--- a/apps/data-extraction/src/extractors/db/actions-db-pages.extractor.ts
+++ b/apps/data-extraction/src/extractors/db/actions-db-pages.extractor.ts
@@ -29,12 +29,14 @@ export class ActionsDbPagesExtractor extends AbstractExtractor {
           {
             field: 'Name',
             koSource: 'koActions',
-            zhSource: 'zhActions'
+            zhSource: 'zhActions',
+            twSource: 'twActions'
           },
           {
             field: 'Description',
             koSource: 'koActionDescriptions',
             zhSource: 'zhActionDescriptions',
+            twSource: 'twActionDescriptions',
             targetField: 'description'
           }
         ]),
@@ -47,12 +49,14 @@ export class ActionsDbPagesExtractor extends AbstractExtractor {
           {
             field: 'Name',
             koSource: 'koCraftActions',
-            zhSource: 'zhCraftActions'
+            zhSource: 'zhCraftActions',
+            twSource: 'twCraftActions'
           },
           {
             field: 'Description',
             koSource: 'koCraftDescriptions',
             zhSource: 'zhCraftDescriptions',
+            twSource: 'twCraftDescriptions',
             targetField: 'description'
           }
         ])
@@ -66,12 +70,14 @@ export class ActionsDbPagesExtractor extends AbstractExtractor {
         {
           field: 'Name',
           koSource: 'koTraits',
-          zhSource: 'zhTraits'
+          zhSource: 'zhTraits',
+          twSource: 'twTraits'
         },
         {
           field: 'Description',
           koSource: 'koTraitDescriptions',
           zhSource: 'zhTraitDescriptions',
+          twSource: 'twTraitDescriptions',
           targetField: 'description'
         }
       ]);

--- a/apps/data-extraction/src/extractors/db/fates-database-pages.extractor.ts
+++ b/apps/data-extraction/src/extractors/db/fates-database-pages.extractor.ts
@@ -19,7 +19,8 @@ export class FatesDatabasePagesExtractor extends AbstractExtractor {
           {
             field: 'Name',
             koSource: 'koFates',
-            zhSource: 'zhFates'
+            zhSource: 'zhFates',
+            twSource: 'twFates'
           },
           {
             field: 'Description',

--- a/apps/data-extraction/src/extractors/db/items-db-pages.extractor.ts
+++ b/apps/data-extraction/src/extractors/db/items-db-pages.extractor.ts
@@ -9,8 +9,10 @@ export class ItemsDbPagesExtractor extends AbstractExtractor {
     const dbData = {};
     const koNames = this.requireLazyFileByKey('koItems');
     const zhNames = this.requireLazyFileByKey('zhItems');
+    const twNames = this.requireLazyFileByKey('twItems');
     const koDescriptions = this.requireLazyFileByKey('koItemDescriptions');
     const zhDescriptions = this.requireLazyFileByKey('zhItemDescriptions');
+    const twDescriptions = this.requireLazyFileByKey('twItemDescriptions');
     const fishes = this.requireLazyFileByKey('fishes');
     const equipment = this.requireLazyFileByKey('equipment');
     const melding = this.requireLazyFileByKey('itemMeldingData');
@@ -148,7 +150,8 @@ export class ItemsDbPagesExtractor extends AbstractExtractor {
               de: item.Name_de,
               fr: item.Name_fr,
               ...(koNames[item.index] || {}),
-              ...(zhNames[item.index] || {})
+              ...(zhNames[item.index] || {}),
+              ...(twNames[item.index] || {})
             },
             description: {
               en: item.Description_en,
@@ -156,7 +159,8 @@ export class ItemsDbPagesExtractor extends AbstractExtractor {
               de: item.Description_de,
               fr: item.Description_fr,
               ...(koDescriptions[item.index] || {}),
-              ...(zhDescriptions[item.index] || {})
+              ...(zhDescriptions[item.index] || {}),
+              ...(twDescriptions[item.index] || {})
             },
             gcReward: supplyDutyReward.find(r => r.index === item.LevelItem)?.SealsExpertDelivery,
             kind: item.ItemKind,

--- a/apps/data-extraction/src/extractors/db/leves-database-pages.extractor.ts
+++ b/apps/data-extraction/src/extractors/db/leves-database-pages.extractor.ts
@@ -26,12 +26,14 @@ export class LevesDatabasePagesExtractor extends AbstractExtractor {
         {
           field: 'Name',
           koSource: 'koLeves',
-          zhSource: 'zhLeves'
+          zhSource: 'zhLeves',
+          twSource: 'twLeves'
         },
         {
           field: 'Description',
           koSource: 'koLeveDescriptions',
           zhSource: 'zhLeveDescriptions',
+          twSource: 'twLeveDescriptions',
           targetField: 'description'
         }
       ]).forEach(({ row, extended }) => {

--- a/apps/data-extraction/src/extractors/db/nodes-database-pages.extractor.ts
+++ b/apps/data-extraction/src/extractors/db/nodes-database-pages.extractor.ts
@@ -10,6 +10,7 @@ export class NodesDatabasePagesExtractor extends AbstractExtractor {
     const nodes = this.requireLazyFileByKey('nodes');
     const koBonuses = this.requireLazyFileByKey('koGatheringBonuses');
     const zhBonuses = this.requireLazyFileByKey('zhGatheringBonuses');
+    const twBonuses = this.requireLazyFileByKey('twGatheringBonuses');
     const gatheringItemsByItemId = Object.entries(this.requireLazyFileByKey('gatheringItems'))
       .reduce((acc, [key, value]) => {
         return {
@@ -71,6 +72,7 @@ export class NodesDatabasePagesExtractor extends AbstractExtractor {
           .map(bonus => {
             const koBonus = koBonuses[bonus.index];
             const zhBonus = zhBonuses[bonus.index];
+            const twBonus = twBonuses[bonus.index];
             return {
               condition: ['en', 'de', 'ja', 'fr'].reduce((acc, lang) => {
                 return {
@@ -79,7 +81,8 @@ export class NodesDatabasePagesExtractor extends AbstractExtractor {
                 };
               }, {
                 ko: koBonus?.condition?.ko?.replace('<Value>IntegerParameter(1)</Value>', koBonus.conditionValue.toString()) || '',
-                zh: zhBonus?.condition?.zh?.replace('<Value>IntegerParameter(1)</Value>', zhBonus.conditionValue.toString()) || ''
+                zh: zhBonus?.condition?.zh?.replace('<Value>IntegerParameter(1)</Value>', zhBonus.conditionValue.toString()) || '',
+                tw: twBonus?.condition?.tw?.replace('<Value>IntegerParameter(1)</Value>', twBonus.conditionValue.toString()) || ''
               }),
               bonus: ['en', 'de', 'ja', 'fr'].reduce((acc, lang) => {
                 return {
@@ -88,7 +91,8 @@ export class NodesDatabasePagesExtractor extends AbstractExtractor {
                 };
               }, {
                 ko: koBonus?.bonus?.ko?.replace('<Value>IntegerParameter(1)</Value>', koBonus.value.toString()) || '',
-                zh: zhBonus?.bonus?.zh?.replace('<Value>IntegerParameter(1)</Value>', zhBonus.value.toString()) || ''
+                zh: zhBonus?.bonus?.zh?.replace('<Value>IntegerParameter(1)</Value>', zhBonus.value.toString()) || '',
+                tw: twBonus?.bonus?.tw?.replace('<Value>IntegerParameter(1)</Value>', twBonus.value.toString()) || ''
               })
             };
           });

--- a/apps/data-extraction/src/extractors/db/npcs-db-pages.extractor.ts
+++ b/apps/data-extraction/src/extractors/db/npcs-db-pages.extractor.ts
@@ -9,6 +9,7 @@ export class NpcsDbPagesExtractor extends AbstractExtractor {
     const pages = {};
     const koTitles = this.requireLazyFileByKey('koNpcTitles');
     const zhTitles = this.requireLazyFileByKey('zhNpcTitles');
+    const twTitles = this.requireLazyFileByKey('twNpcTitles');
     const quests = this.requireLazyFileByKey('quests');
     combineLatest([
       this.getSheet<any>(xiv, 'ENpcBase', ['EnpcData']),
@@ -23,7 +24,8 @@ export class NpcsDbPagesExtractor extends AbstractExtractor {
           title: {
             ...npc.title,
             ...(koTitles[npc.id] || {}),
-            ...(zhTitles[npc.id] || {})
+            ...(zhTitles[npc.id] || {}),
+            ...(twTitles[npc.id] || {})
           },
           quests: base.ENpcData
             .filter(id => id >= 65530 && id <= 70000)

--- a/apps/data-extraction/src/extractors/db/quests-db-pages.extractor.ts
+++ b/apps/data-extraction/src/extractors/db/quests-db-pages.extractor.ts
@@ -21,6 +21,7 @@ export class QuestsDbPagesExtractor extends AbstractExtractor {
     const textIndex = {};
     const koDescriptions = this.requireLazyFileByKey('koQuestDescriptions');
     const zhDescriptions = this.requireLazyFileByKey('zhQuestDescriptions');
+    const twDescriptions = this.requireLazyFileByKey('twQuestDescriptions');
     this.getSheet<any>(xiv, 'Quest',
       [
         'IssuerStart#',
@@ -59,7 +60,8 @@ export class QuestsDbPagesExtractor extends AbstractExtractor {
                     ja: textCSV[2]['1_ja'],
                     fr: textCSV[2]['1_fr'],
                     ko: koDescriptions[quest.id]?.ko,
-                    zh: zhDescriptions[quest.id]?.zh
+                    zh: zhDescriptions[quest.id]?.zh,
+                    tw: twDescriptions[quest.id]?.tw
                   },
                   chainLength: questChainLengths[+quest.id],
                   genre: row.JournalGenre,

--- a/apps/data-extraction/src/extractors/db/statuses-db-pages.extractor.ts
+++ b/apps/data-extraction/src/extractors/db/statuses-db-pages.extractor.ts
@@ -10,12 +10,14 @@ export class StatusesDbPagesExtractor extends AbstractExtractor {
         {
           field: 'Name',
           koSource: 'koStatuses',
-          zhSource: 'zhStatuses'
+          zhSource: 'zhStatuses',
+          twSource: 'twStatuses'
         },
         {
           field: 'Description',
           koSource: 'koStatusDescriptions',
           zhSource: 'zhStatusDescriptions',
+          twSource: 'twStatusDescriptions',
           targetField: 'description'
         }
       ]).forEach(({ row, extended }) => {

--- a/apps/data-extraction/src/extractors/db/traits-db-pages.extractor.ts
+++ b/apps/data-extraction/src/extractors/db/traits-db-pages.extractor.ts
@@ -25,12 +25,14 @@ export class TraitsDbPagesExtractor extends AbstractExtractor {
         {
           field: 'Name',
           koSource: 'koTraits',
-          zhSource: 'zhTraits'
+          zhSource: 'zhTraits',
+          twSource: 'twTraits'
         },
         {
           field: 'Description',
           koSource: 'koTraitDescriptions',
           zhSource: 'zhTraitDescriptions',
+          twSource: 'twTraitDescriptions',
           targetField: 'description'
         }
       ]).forEach(({ row, extended }) => {

--- a/apps/data-extraction/src/extractors/search.extractor.ts
+++ b/apps/data-extraction/src/extractors/search.extractor.ts
@@ -50,7 +50,8 @@ export class SearchExtractor extends AbstractExtractor {
       ja: row.ja,
       fr: row.fr,
       ko: row.ko,
-      zh: row.zh
+      zh: row.zh,
+      tw: row.tw,
     };
   }
 
@@ -295,6 +296,7 @@ export class SearchExtractor extends AbstractExtractor {
       const names = this.getExtendedNames<LazyNpc>('npcs');
       const koTitles = this.requireLazyFileByKey('koNpcTitles');
       const zhTitles = this.requireLazyFileByKey('zhNpcTitles');
+      const twTitles = this.requireLazyFileByKey('twNpcTitles');
       const index = names.map((row) => {
         return {
           ...this.getBaseEntry(row),
@@ -304,7 +306,8 @@ export class SearchExtractor extends AbstractExtractor {
             title: {
               ...row.title,
               ...koTitles[row.id],
-              ...zhTitles[row.id]
+              ...zhTitles[row.id],
+              ...twTitles[row.id]
             }
           }
         };
@@ -413,6 +416,7 @@ export class SearchExtractor extends AbstractExtractor {
       const names = this.getExtendedNames<LazyStatus>('statuses');
       const koDescriptions = this.requireLazyFileByKey('koStatusDescriptions');
       const zhDescriptions = this.requireLazyFileByKey('zhStatusDescriptions');
+      const twDescriptions = this.requireLazyFileByKey('twStatusDescriptions');
       const index = names.map((row) => {
         return {
           ...this.getBaseEntry(row),
@@ -423,7 +427,8 @@ export class SearchExtractor extends AbstractExtractor {
             description: {
               ...row.description,
               ...koDescriptions[row.id],
-              ...zhDescriptions[row.id]
+              ...zhDescriptions[row.id],
+              ...twDescriptions[row.id]
             }
           }
         };

--- a/libs/types/src/lib/lazy-data-types.ts
+++ b/libs/types/src/lib/lazy-data-types.ts
@@ -35,9 +35,12 @@ type LazyDataKoreanEntries = { [K in keyof LazyData]: K extends `ko${string}` ? 
 
 type LazyDataChineseEntries = { [K in keyof LazyData]: K extends `zh${string}` ? K : never }[keyof LazyData];
 
+type LazyDataTraditionalChineseEntries = { [K in keyof LazyData]: K extends `tw${string}` ? K : never }[keyof LazyData];
+
 export type LazyDataI18nKey = keyof Pick<LazyData, LazyDataI18nEntries>;
 export type LazyDataKoreanKey = keyof Pick<LazyData, LazyDataKoreanEntries>;
 export type LazyDataChineseKey = keyof Pick<LazyData, LazyDataChineseEntries>;
+export type LazyDataTraditionalChineseKey = keyof Pick<LazyData, LazyDataTraditionalChineseEntries>;
 
 
 


### PR DESCRIPTION
Since packet capture might soon be added for the TW version, I took a look at what is missing for the search and database pages to work for it.

The changes are just copy-paste from what is done for `zh` and `ko`. (There are actually more places where `tw` isn't being accounted for in the same way, but I didn't have an easy way of testing if changes to those would work, and didn't want to bloat the scope of this PR.)

I'm not including the generated files in the PR since the db page creation uses `SaintCoinach.Cmd`, which only runs on Windows. I did test it with some modifications to use CSV files generated by [XIVData Oxidizer](https://github.com/skyborn-industries/xiv-data-oxidizer) though.

<img width="1173" height="716" alt="screenshot showing the search working with TW selected" src="https://github.com/user-attachments/assets/328293fd-2aad-4e81-bc37-940595e32335" />

<img width="1176" height="714" alt="screenshot showing an item db page with TW selected" src="https://github.com/user-attachments/assets/909a485a-1f95-49e0-a4d6-7bf1debaecd1" />

`./assets/icons/taiwan.png` currently 404s since it doesn't exist yet.
(The craft type and patch text not loading in is seemingly an issue for all non-global versions / also happens on the main site for `KO` and `ZH`)