### PR TITLE
fix(allagan-reports): Editing a fish report form not prepopulated wit…

### DIFF
--- a/apps/client/src/app/pages/allagan-reports/allagan-report-details/allagan-report-details.component.ts
+++ b/apps/client/src/app/pages/allagan-reports/allagan-report-details/allagan-report-details.component.ts
@@ -602,7 +602,17 @@ export class AllaganReportDetailsComponent extends ReportsManagementComponent {
               predators: report.data.predators,
               oceanFishingTime: report.data.oceanFishingTime,
               minGathering: report.data.minGathering,
-              fruityVideo: report.data.fruityVideo
+              fruityVideo: report.data.fruityVideo,
+              lure: report.data.aLure > 0 ? 3972
+                : report.data.mLure > 0
+                  ? 3973
+                  : null,
+
+              lureStacks: report.data.aLure > 0
+                ? report.data.aLure
+                : report.data.mLure > 0
+                  ? report.data.mLure
+                  : null,
             }, value => value !== undefined && value !== null);
           })
         );


### PR DESCRIPTION
…h saved lure type and stacks

The issue presented when a fish that had lure stacks in its Allagan Report, was missing them, after an update. I confirmed that choosing any report with lures populated, and clicking Edit, caused the form for lures to appear empty, which lead to the editor unknowingly changing it (removing lure stacks) when modifying an unrelated to field.

This fix works in a local build, but I am not 100% sure it's the best way to solve it. I focused on not adjusting the display component, only the data populated into the form after clicking Edit. If there's a better/cleaner way, feel free to advise or tell me to look harder!

Thank you for TC and Allagan Reports! It's a crucial resource for the fisher community!