### PR TITLE
fix(toolchain): drastically reduce build times and enable Windows cross-compilation

### DIFF
--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -3122,11 +3122,13 @@
       "GAME_RUNNING_AS_ADMIN": "Game is running as admin, please either restart it normally or restart Teamcraft as admin.",
       "MISSING_INJECTOR": "Packet capture tooling is missing, most likely removed by your antivirus due to a false positive, make sure to whitelist Teamcraft's install folder and reinstall it.",
       "BRIDGE_PATHS_NOT_CONFIGURED": "One or more required settings for packet capture (Wine/Proton prefix, Wine binary, or FFXIV config directory) are missing. Please change them in Settings.",
-      "BRIDGE_BRIDGE_ERROR": "Check your Wine settings and re-enable packet capture. If the issue persists, check the application logs for more details.",
+      "BRIDGE_ERROR": "Check your Wine settings and re-enable packet capture. If the issue persists, check the application logs for more details.",
+      "BRIDGE_CRASHED": "The packet capture bridge crashed unexpectedly. Try using a different version of Wine or Proton, and if you still have issues, please report to discord's #troubleshooting channel.",
       "BRIDGE_GAME_NOT_RUNNING": "Please make sure the game is running before enabling packet capture.<br>If this issue persists, please report to discord's #troubleshooting channel with a screenshot of the above messages."
     },
     "BRIDGE_PATHS_NOT_CONFIGURED": "Wine paths not configured",
-    "BRIDGE_BRIDGE_ERROR": "Packet capture failed to start",
+    "BRIDGE_ERROR": "Packet capture failed to start",
+    "BRIDGE_CRASHED": "Packet capture crashed",
     "BRIDGE_GAME_NOT_RUNNING": "Packet capture failed to start"
   },
   "ISLAND_SANCTUARY": {

--- a/apps/electron/src/pcap/packet-capture.ts
+++ b/apps/electron/src/pcap/packet-capture.ts
@@ -551,14 +551,14 @@ export class PacketCapture {
     this.bridgeProcess.on('exit', (code, signal) => {
       log.info(`[bridge] exited code=${code} signal=${signal}`);
       this.bridgeProcess = null;
-      // code=null means we killed it intentionally (SIGTERM). Any explicit
-      // non-zero exit code means the bridge itself detected an error.
-      if (code !== null && code !== 0 && this.captureInterface) {
+      // We only ever kill the bridge ourselves with the default SIGTERM, so any other
+      // signal (e.g. SIGFPE, SIGSEGV) means it actually crashed, not that we stopped it.
+      if (((code !== null && code !== 0) || (signal !== null && signal !== 'SIGTERM')) && this.captureInterface) {
         log.error(`[bridge] Abnormal exit (stderr: ${stderrBuffer.trim()})`);
         this.store.set('machina', false);
         this.mainWindow.win.webContents.send('toggle-pcap:value', false);
         this.mainWindow.win.webContents.send('pcap:status', 'error');
-        this.mainWindow.win.webContents.send('pcap:error', { message: 'BRIDGE_ERROR' });
+        this.mainWindow.win.webContents.send('pcap:error', { message: 'BRIDGE_CRASHED' });
         this.stop();
       }
     });


### PR DESCRIPTION
## Goal

Production builds take too long and require a Windows machine to release. This PR makes both problems go away.

| Job | Before | After | Saved |
|---|---|---|---|
| setup (install) | 6m 03s | 1m 58s | **−4m 05s (67%)** |
| lint | 1m 34s | 1m 19s | −0m 15s (16%) |
| build-api | 3m 53s | 1m 09s | **−2m 44s (70%)** |
| build (Angular + Electron) | 5m 10s | 2m 35s | **−2m 35s (50%)** |
| **Critical path total** | **12m 47s** | **5m 52s** | **−6m 55s (54%)** |

**Measured improvements on a cold cache:**

| Step | Before | After | Improvement |
|---|---|---|---|
| `bun install` from lockfile | ~15–20 s | ~3.4 s | **~5× faster** |
| Full production build (Angular + Electron + package) | ~71.5 s | ~40 s | **~44% faster** |

No application logic changed. The ~300 Angular component files in the diff are automated output from the Angular 19 migration tool, which adds explicit `standalone: false` to all NgModule-based components — a required annotation in Angular 19.

## How the install speedup works: Yarn → Bun

Bun's package manager resolves and links packages roughly 5× faster than Yarn Classic. Replacing it across the entire toolchain means every developer install, every CI setup step, and every `bun install` triggered by a lockfile change is dramatically faster.

- `yarn.lock` removed; `bun.lock` is the sole lockfile
- All `yarn <cmd>` script references replaced with `bun run <cmd>`
- NX 19 upgraded to 20.8.4 and Angular 18 upgraded to 19.2.9 — required because NX 19 has no Bun support (`packageManager: "bun"` throws); NX 20.8.4 reads `bun.lock` natively
- `nx.js` shim at the project root (`#!/usr/bin/env bun`) routes all NX invocations through Bun's JS engine, removing Node.js from the execution path entirely
- All explicit `node ./tools/build/…` and `tsc` shebang calls replaced with `bun` equivalents
- Node.js is no longer a contributor prerequisite

## How the build speedup works: parallelism + esbuild

The production build was fully sequential: prebuild → Angular client (30–35 s) → assets hash → Electron main (5 s) → preload tsc → electron-builder. The Angular client and Electron main are completely independent and were waiting on each other for no reason.

`tools/build/build-parallel.js` runs them in parallel:

```
prebuild  →  data:build (shared dep, run once to warm cache)
                 ↓ parallel ──────────────────────────────┐
     Angular client:build (~23 s)          Electron main esbuild (~5 s)
       → assets:hash                         → copyfiles + preload tsc
                 ↓ ───────────────────────────────────────┘
             electron-builder
```

The Electron main process was also migrated from webpack to esbuild. Webpack was unnecessary overhead for a ~100-line Node.js entry point — esbuild produces the same output in ~5 s with zero configuration beyond marking `node_modules` external.

All production build scripts (`build:windows`, `build:appimage`, `electron:setup:build`, etc.) now use the parallel driver.

## How Windows cross-compilation works

The Windows Squirrel installer is now built from Linux using `mono` (which runs `Squirrel.exe`) and `osslsigncode` (for Authenticode signing). The old CI job used a Windows executor with 8 manual setup steps; it is replaced by a standard Linux job.

- `bun run build:windows` — unsigned installer, for local testing
- `bun run build:windows:publish` — signed installer; fails immediately if `WIN_CSC_LINK` is unset or points to a nonexistent file
- On Linux: `osslsigncode` handles signing; on Windows: `certutil` + `signtool.exe` (unchanged)
- CI `release-desktop` job now uses the same Linux executor as `release-desktop-linux`

## NX 19 → 20.8.4 and Angular 18 → 19.2.9

NX 19 has no Bun runtime support (`packageManager: "bun"` throws). NX 20.8.4 reads `bun.lock` natively. Angular 19 was upgraded alongside NX 20 via `nx migrate`.

- 27 automated NX/Angular migration scripts ran
- `@angular/fire` manually updated 18.0.1 → 19.2.0 (peer dependency of Angular 19)
- `useLegacyCache: true` removed from `nx.json` (was set by the NX 20 migration shim; NX 20's native cache is now used)
- All `@nrwl/` executor references updated to their `@nx/` equivalents across all `project.json` files (`@nrwl/webpack:webpack` → `@nx/webpack:webpack`, `@nrwl/js:node` → `@nx/js:node`, `@nrwl/js:tsc` → `@nx/js:tsc`, `@nrwl/linter:eslint` → `@nx/eslint:lint`) — the `@nrwl/` namespace was removed in NX 20
- `webpack.node.config.js` added at project root — a minimal pass-through for the `api`, `data-extraction`, and `lodestone-api` Node apps which need `isolatedConfig` mode; these apps were previously sharing `apps/electron/webpack.config.js` (a no-op file deleted when electron migrated to esbuild)
- Two TypeScript errors introduced by the Angular 19 / NgRx 19 / TypeScript 5.7 upgrade were fixed:
  1. `tsconfig.base.json`: `"es2023"` added to `lib` (`Array.prototype.toReversed` requires it); redundant `"es2017"` and `"es2020"` entries removed (subsumed by `"es2023"`)
  2. `apps/client/src/app/core/rxjs/lazy-loaded.ts`: parameter type changed from `Observable<Parameters<Store['dispatch']>[0]>` to `Observable<Action>` — NgRx 19 changed the `dispatch` overload order, causing TypeScript to resolve the parameter type as `ActionCreator` (a function) rather than `Action` (an instance); subscription teardown also fixed (see below)
