### PR TITLE
chore: include prebuild in dev env setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@
 
 * Install [Node.js](http://nodejs.org/) (>= 22.14) and Yarn (`npm i -g yarn`)
 * Install local dev dependencies: `yarn` while current directory is this repo
+* Set up environment: `yarn prebuild` while current directory is this repo
 
 #### Windows 10 environment
 


### PR DESCRIPTION
When setting up my own environment, I hit an issue where the version.ts file didn't exist in `apps/client/src/environments`, causing the start script to fail. Eventually, I looked through the package.json file and found the prebuild script. Running that solved the issue.

It's either this, or adding `yarn prebuild &&` to the `start` script. I'm not sure which is preferred here.