### PR TITLE
refactor(currency-spending): reorganize currency spending information into table

### DIFF
--- a/apps/client/src/app/core/rxjs/requests-with-delay.ts
+++ b/apps/client/src/app/core/rxjs/requests-with-delay.ts
@@ -1,14 +1,14 @@
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { bufferCount, delay, mergeMap, tap } from 'rxjs/operators';
 
-export function requestsWithDelay(requests: Observable<any>[], _delay: number, emit: true): Observable<any>
-export function requestsWithDelay(requests: Observable<any>[], _delay: number, emit ?: false): Observable<any[]>
-export function requestsWithDelay(requests: Observable<any>[], _delay: number, emit = false): Observable<any | any[]> {
+export function requestsWithDelay<T>(requests: Observable<T>[], _delay: number, emit: true): Observable<T>
+export function requestsWithDelay<T>(requests: Observable<T>[], _delay: number, emit ?: false): Observable<T[]>
+export function requestsWithDelay<T>(requests: Observable<T>[], _delay: number, emit = false): Observable<T | T[]> {
   if (requests.length === 0) {
     return of([]);
   }
   const index$ = new BehaviorSubject(0);
-  return index$.pipe(
+  const pipeline = index$.pipe(
     delay(_delay),
     mergeMap(index => {
       return requests[index].pipe(
@@ -18,7 +18,7 @@ export function requestsWithDelay(requests: Observable<any>[], _delay: number, e
           }
         })
       );
-    }),
-    emit ? tap() : bufferCount(requests.length)
+    })
   );
+  return emit ? pipeline : pipeline.pipe(bufferCount(requests.length));
 }

--- a/apps/client/src/app/pages/currency-spending/currency-spending/currency-spending.component.html
+++ b/apps/client/src/app/pages/currency-spending/currency-spending/currency-spending.component.html
@@ -24,7 +24,7 @@
       }
     </nz-select>
     <nz-input-number (ngModelChange)="amount$.next($event)" [ngModel]="amount$ | async" [nzPlaceHolder]="'COMMON.Amount' | translate"
-    [nzStep]="1"></nz-input-number>
+    [nzStep]="1" [nzMin]="0"></nz-input-number>
     <nz-select
       (ngModelChange)="server$.next($event)"
       [ngModel]="server$ | async"
@@ -59,49 +59,51 @@
 
 @if (results$ | async; as results) {
   @if (!loading) {
-    <nz-list [nzDataSource]="results" [nzRenderItem]="item" [nzNoResult]="noTrades">
+    <nz-table #currencySpendingTable [nzData]="results" [nzNoResult]="noTrades" class="spending-table" nzSize="small">
       <ng-template #noTrades>
         <nz-empty [nzNotFoundContent]="'CURRENCY_SPENDING.No_trades' | translate"></nz-empty>
       </ng-template>
-      <ng-template #item let-item>
-        <nz-list-item [nzContent]="content" class="result-item">
-          <ng-template #content>
-            <div fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
-              <div>{{item.npcs[0] | i18nRow:'npcs' | i18n}}</div>
-              <app-db-button [id]="item.npcs[0]" type="npc"></app-db-button>
-            </div>
-          </ng-template>
-          <nz-list-item-meta
-            [nzAvatar]="avatar"
-            [nzDescription]="description"
-            [nzTitle]="nzTitle"
-            >
-            <ng-template #description>
-              <div fxLayout="row" fxLayoutAlign="flex-start center">
-                <div>{{'CURRENCY_SPENDING.You_can_buy' | translate: { amount: (item.rate * (amount$ | async) | floor) } }},&nbsp;</div>
-                <div>{{'MARKETBOARD.Unit_price' | translate}}:</div>
-                <app-item-icon [icon]="1 | lazyIcon" [itemId]="1" [width]="32"></app-item-icon>
-                <div>x {{item.price | number}},&nbsp;</div>
-                <div>{{'COMMON.Total' | translate}}:</div>
-                <app-item-icon [icon]="1 | lazyIcon" [itemId]="1" [width]="32"></app-item-icon>
-                <div>x {{(item.price * (item.rate * (amount$ | async) | floor)) | number}}</div>
-                <div>&nbsp;({{'CURRENCY_SPENDING.X_sold_last_week' | translate:{ amount: item.amountSoldLastWeek } }})</div>
-              </div>
-            </ng-template>
-            <ng-template #avatar>
+      <thead (nzSortOrderChange)="sort($event)">
+        <tr>
+          <th>Name</th>
+          <th nzShowSort [nzSortFn]="true" nzColumnKey="amount">{{ 'CURRENCY_SPENDING.You_can_buy' | translate }}</th>
+          <th nzShowSort [nzSortFn]="true" nzColumnKey="exchangeRate">{{ 'CURRENCY_SPENDING.Exchange_rate' | translate }}</th>
+          <th nzShowSort [nzSortFn]="true" nzColumnKey="price">
+            {{ 'CURRENCY_SPENDING.Price' | translate }}
+            <app-item-icon [icon]="1 | lazyIcon" [itemId]="1" [width]="32"></app-item-icon>
+          </th>
+          <th nzShowSort [nzSortFn]="true" nzColumnKey="total">
+            {{ 'CURRENCY_SPENDING.Total_earnings' | translate }}
+            <app-item-icon [icon]="1 | lazyIcon" [itemId]="1" [width]="32"></app-item-icon>
+          </th>
+          <th nzShowSort [nzSortFn]="true" nzColumnKey="amountSoldLastWeek">{{ 'CURRENCY_SPENDING.Sold_last_week' | translate }}</th>
+          <th>{{ 'CURRENCY_SPENDING.Npc' | translate }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (item of currencySpendingTable.data; track item) {
+          <tr>
+            <td fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
               <app-item-icon [hq]="item.HQ" [icon]="item.item | lazyIcon" [itemId]="item.item"
               [width]="32"></app-item-icon>
-            </ng-template>
-            <ng-template #nzTitle>
+              <app-i18n-name [id]="item.item" content="items"></app-i18n-name>
+              <app-db-button [id]="item.item" type="item"></app-db-button>
+              <app-marketboard-icon [itemId]="item.item" [showHistory]="true"></app-marketboard-icon>
+            </td>
+            <td>{{ item.amount | number }}</td>
+            <td>{{ item.exchangeRate | number }}</td>
+            <td>{{ item.price | number }}</td>
+            <td>{{ item.total | number }}</td>
+            <td>{{ item.amountSoldLastWeek }}</td>
+            <td>
               <div fxLayout="row" fxLayoutAlign="flex-start center" fxLayoutGap="5px">
-                <div><app-i18n-name [id]="item.item" content="items"></app-i18n-name></div>
-                <app-db-button [id]="item.item" type="item"></app-db-button>
-                <app-marketboard-icon [itemId]="item.item" [showHistory]="true"></app-marketboard-icon>
+                <div>{{item.npcs[0] | i18nRow:'npcs' | i18n}}</div>
+                <app-db-button [id]="item.npcs[0]" type="npc"></app-db-button>
               </div>
-            </ng-template>
-          </nz-list-item-meta>
-        </nz-list-item>
-      </ng-template>
-    </nz-list>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </nz-table>
   }
 }

--- a/apps/client/src/app/pages/currency-spending/currency-spending/currency-spending.component.less
+++ b/apps/client/src/app/pages/currency-spending/currency-spending/currency-spending.component.less
@@ -30,3 +30,7 @@
     width: 100%;
   }
 }
+
+.spending-table { 
+  padding-top: 10px;
+}

--- a/apps/client/src/app/pages/currency-spending/currency-spending/currency-spending.component.ts
+++ b/apps/client/src/app/pages/currency-spending/currency-spending/currency-spending.component.ts
@@ -21,7 +21,7 @@ import { MarketboardIconComponent } from '../../../modules/marketboard/marketboa
 import { ItemIconComponent } from '../../../modules/item-icon/item-icon/item-icon.component';
 import { DbButtonComponent } from '../../../core/db-button/db-button.component';
 import { NzEmptyModule } from 'ng-zorro-antd/empty';
-import { NzListModule } from 'ng-zorro-antd/list';
+import { NzTableModule } from 'ng-zorro-antd/table';
 import { NzProgressModule } from 'ng-zorro-antd/progress';
 import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 import { I18nNameComponent } from '../../../core/i18n/i18n-name/i18n-name.component';
@@ -29,13 +29,15 @@ import { AsyncPipe, DecimalPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NzSelectModule } from 'ng-zorro-antd/select';
 import { FlexModule } from '@angular/flex-layout/flex';
+import { LazyShop } from '@ffxiv-teamcraft/data/model/lazy-shop';
+import { MarketboardItem } from '../../../core/api/market/marketboard-item';
 
 @Component({
   selector: 'app-currency-spending',
   templateUrl: './currency-spending.component.html',
   styleUrls: ['./currency-spending.component.less'],
   standalone: true,
-  imports: [FlexModule, NzSelectModule, FormsModule, I18nNameComponent, NzInputNumberModule, NzProgressModule, NzListModule, NzEmptyModule, DbButtonComponent, ItemIconComponent, MarketboardIconComponent, AsyncPipe, DecimalPipe, I18nPipe, TranslateModule, I18nRowPipe, ItemNamePipe, FloorPipe, LazyIconPipe]
+  imports: [FlexModule, NzSelectModule, FormsModule, I18nNameComponent, NzInputNumberModule, NzProgressModule, NzTableModule, NzEmptyModule, DbButtonComponent, ItemIconComponent, MarketboardIconComponent, AsyncPipe, DecimalPipe, I18nPipe, TranslateModule, I18nRowPipe, ItemNamePipe, FloorPipe, LazyIconPipe]
 })
 export class CurrencySpendingComponent extends TeamcraftComponent implements OnInit {
 
@@ -45,11 +47,16 @@ export class CurrencySpendingComponent extends TeamcraftComponent implements OnI
 
   public results$: Observable<SpendingEntry[]>;
 
-  public amount$: BehaviorSubject<number> = new BehaviorSubject<number>(null);
+  public amount$: BehaviorSubject<number | null> = new BehaviorSubject<number | null>(null);
 
   public servers$: Observable<string[]>;
 
   public server$: Subject<string> = new Subject<string>();
+
+  public sort$: BehaviorSubject<SortPair> = new BehaviorSubject<SortPair>({
+    key: 'score',
+    value: 'ascend'
+  });
 
   public loading = false;
 
@@ -92,94 +99,34 @@ export class CurrencySpendingComponent extends TeamcraftComponent implements OnI
     this.results$ = combineLatest([this.currency$, this.server$]).pipe(
       switchMap(([currency, server]) => {
         this.loading = true;
-        return combineLatest([
+        const spendingEntries = combineLatest([
           this.lazyData.getEntry('shops'),
-          this.lazyData.getEntry('marketItems')
+          this.lazyData.getEntry('marketItems'),
         ]).pipe(
-          map(([shops, marketItems]) => {
-            return shops
-              .filter(shop => {
-                return shop.trades.some(t => {
-                  return t.currencies.some(c => c.id === currency)
-                    && t.items.some(i => marketItems.includes(i.id));
-                });
-              })
-              .map(shop => {
-                return shop.trades
-                  .filter(t => t.items.length > 0 && t.currencies.some(c => c.id === currency))
-                  .map(t => {
-                    const currencyEntry = t.currencies.find(c => +c.id === currency);
-                    return {
-                      npcs: shop.npcs,
-                      item: +t.items[0].id,
-                      HQ: +t.items[0].hq,
-                      rate: +t.items[0].amount / currencyEntry.amount
-                    };
-                  });
-              })
-              .flat();
-          }),
-          switchMap(entries => {
-            if (entries.length === 0) {
-              return of([]);
+          map(([shops, marketItems]) => this.getItemInfos(shops, marketItems, currency)),
+          switchMap(entries => this.processMarketData(entries, server, currency))
+        );
+
+        // Extend spending entries with amount information, don't trigger universalis requests
+        const extendedSpendingEntries = combineLatest([spendingEntries, this.amount$]).pipe(
+          map(([entries, currencyAmount]) => this.computeValueWithAmount(entries, currencyAmount))
+        )
+
+        // Sort with full entries
+        return combineLatest([extendedSpendingEntries, this.sort$]).pipe(
+          map(([data, sort]) => [...data].sort((a, b) => {
+            if (sort.value === 'ascend') {
+              if (a[sort.key] === b[sort.key]) {
+                return a.score! > b.score! ? 1 : -1;
+              }
+              return a[sort.key] > b[sort.key] ? 1 : -1;
+            } else {
+              if (a[sort.key] === b[sort.key]) {
+                return a.score! > b.score! ? 1 : -1;
+              }
+              return a[sort.key] < b[sort.key] ? 1 : -1;
             }
-            const batches = chunk(entries, 100)
-              .map((chunk: any) => {
-                return this.universalis.getServerHistoryPrices(
-                  server,
-                  ...chunk.map(entry => entry.item)
-                );
-              });
-            this.tradesCount = entries.length;
-            return requestsWithDelay(batches, 250, true).pipe(
-              tap(res => {
-                this.loadedPrices = Math.min(this.tradesCount, this.loadedPrices + res.length);
-              }),
-              bufferCount(batches.length),
-              first(),
-              map(res => {
-                return [].concat.apply([], res)
-                  .filter(mbRow => {
-                    return mbRow.History && mbRow.History.length > 0 || mbRow.Prices && mbRow.Prices.length > 0;
-                  });
-              }),
-              switchMap((res) => {
-                return safeCombineLatest(entries
-                  .filter(entry => {
-                    return res.some(r => r.ItemId === entry.item);
-                  })
-                  .map(entry => {
-                    return this.lazyData.getRow('extracts', entry.item).pipe(
-                      map(extract => {
-                        const mbRow = res.find(r => r.ItemId === entry.item);
-                        const avgPrice = mbRow.History.reduce((prev, curr) => {
-                          return prev.pricePerUnit < curr.pricePerUnit ? prev : curr;
-                        }).pricePerUnit;
-                        const amountSoldLastWeek = Math.floor(mbRow.regularSaleVelocity * 7);
-                        return <SpendingEntry>{
-                          ...entry,
-                          HQ: entry.HQ === 1,
-                          itemID: entry.item,
-                          npcs: getItemSource(extract, DataType.TRADE_SOURCES)
-                            .filter(trade => trade.trades.some(t => t.currencies.some(c => c.id === currency)))
-                            .map(tradeSource => tradeSource.npcs.filter(npc => !npc.festival).map(npc => npc.id)).flat(),
-                          price: avgPrice,
-                          score: avgPrice / entry.rate * amountSoldLastWeek,
-                          amountSoldLastWeek
-                        };
-                      })
-                    );
-                  })
-                );
-              }),
-              map((res: SpendingEntry[]) => {
-                return uniqBy(res.filter(entry => entry.price), 'itemID')
-                  .sort((a, b) => {
-                    return b.score - a.score;
-                  });
-              })
-            );
-          })
+          }))
         );
       }),
       tap(() => {
@@ -188,6 +135,118 @@ export class CurrencySpendingComponent extends TeamcraftComponent implements OnI
         this.loadedPrices = 0;
       })
     );
+
+    // Default to sorting by Gil / currency
+    this.sort$.next({key: 'exchangeRate', value: 'descend'})
+  }
+
+  getItemInfos(shops: LazyShop[], marketItems: number[], currency: number): ItemInfo[] {
+    return shops
+      .filter(shop => {
+        return shop.trades.some(t => {
+          return t.currencies.some(c => c.id === currency)
+            && t.items.some(i => marketItems.includes(i.id));
+        });
+      })
+      .map(shop => {
+        return shop.trades
+          .filter(t => t.items.length > 0 && t.currencies.some(c => c.id === currency))
+          .map(t => {
+            const currencyEntry = t.currencies.find(c => c.id === currency)!;
+            return {
+              npcs: shop.npcs,
+              item: +t.items[0].id,
+              HQ: t.items[0].hq || false,
+              rate: +t.items[0].amount / currencyEntry.amount
+            };
+          });
+      })
+      .flat();
+  }
+
+  processMarketData(entries: ItemInfo[], server: string, currency: number) {
+    if (entries.length === 0) {
+      return of([]);
+    }
+    this.tradesCount = entries.length;
+    return this.getMarketboardListings(entries, server).pipe(
+      switchMap((res) => {
+        return safeCombineLatest(entries
+          .filter(entry => {
+            return res.some(r => r.ItemId === entry.item);
+          })
+          .map(entry => {
+            return this.lazyData.getRow('extracts', entry.item).pipe(
+              map(extract => {
+                const mbRow = res.find(r => r.ItemId === entry.item)!;
+                const avgPrice = mbRow.History.reduce((prev, curr) => {
+                  return prev.PricePerUnit < curr.PricePerUnit ? prev : curr;
+                }).PricePerUnit;
+                const amountSoldLastWeek = Math.floor(mbRow.nqSaleVelocity * 7);
+                const exchangeRate = avgPrice * entry.rate;
+                return <SpendingEntry>{
+                  ...entry,
+                  HQ: entry.HQ,
+                  itemID: entry.item,
+                  npcs: getItemSource(extract!, DataType.TRADE_SOURCES)
+                    .filter(trade => trade.trades.some(t => t.currencies.some(c => c.id === currency)))
+                    .map(tradeSource => tradeSource.npcs.filter(npc => !npc.festival).map(npc => npc.id)).flat(),
+                  price: avgPrice,
+                  score: avgPrice / entry.rate * amountSoldLastWeek,
+                  amountSoldLastWeek: amountSoldLastWeek,
+                  exchangeRate: exchangeRate
+                };
+              })
+            );
+          })
+        );
+      }),
+      map((res: SpendingEntry[]) => {
+        return uniqBy(res.filter(entry => entry.price), 'itemID');
+      })
+    );
+  }
+
+  // Get the universalis market entries for all of the items requested on a server
+  getMarketboardListings(entries: ItemInfo[], server: string): Observable<MarketboardItem[]> {
+    // Batch items into max items in universalis request
+    const batches = chunk(entries, 100)
+      .map((chunk) => {
+        return this.universalis.getServerHistoryPrices(
+          server,
+          ...chunk.map(entry => entry.item)
+        );
+      });
+    this.tradesCount = entries.length;
+    // Make sure unviersalis isn't overloaded with requests
+    return requestsWithDelay(batches, 250, true).pipe(
+      // Update loading count of prices
+      tap(res => {
+        this.loadedPrices = Math.min(this.tradesCount, this.loadedPrices + res.length);
+      }),
+      bufferCount(batches.length),
+      first(),
+      map(res => {
+        return res.flat()
+          // make sure the item has been sold
+          .filter(mbRow => {
+            return mbRow.History && mbRow.History.length > 0 || mbRow.Prices && mbRow.Prices.length > 0;
+          });
+    }));
+  }
+
+  computeValueWithAmount(entries: SpendingEntry[], currencyAmount: number | null): SpendingEntry[] {
+    return entries.map((entry) => {
+      // If null, assume no currency
+      currencyAmount = currencyAmount || 0;
+      const amountPurchaseable = Math.floor(entry.rate! * currencyAmount)
+      const totalValue = amountPurchaseable * entry.price;
+      return {
+        ...entry,
+        amount: amountPurchaseable,
+        total: totalValue
+      };
+    });
   }
 
   ngOnInit(): void {
@@ -210,4 +269,20 @@ export class CurrencySpendingComponent extends TeamcraftComponent implements OnI
     });
   }
 
+  sort(event: any): void {
+    this.sort$.next({ key: event.key, value: event.value });
+  }
+
+}
+
+type SortPair = {
+  key: keyof SpendingEntry,
+  value: 'ascend' | 'descend'
+}
+
+type ItemInfo = {
+  npcs: number[];
+  item: number;
+  HQ: boolean;
+  rate: number;
 }

--- a/apps/client/src/app/pages/currency-spending/spending-entry.ts
+++ b/apps/client/src/app/pages/currency-spending/spending-entry.ts
@@ -5,4 +5,11 @@ export interface SpendingEntry {
   npcs?: number[];
   HQ?: boolean;
   score?: number;
+  amountSoldLastWeek?: number;
+  amount?: number;
+  total?: number;
+  exchangeRate?: number;
+
+  // Permit indexing into the SpendingEntry
+  [key: string]: any;
 }

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -1983,12 +1983,16 @@
     "Title": "Currency Spending guide",
     "Description": "Got too much of a currency? Select your currency, set an amount, select a server, and find which item is the best to buy to get gil from your currencies!",
     "Pick_currency": "Pick a currency",
-    "You_can_buy": "You can buy {{amount}}",
+    "You_can_buy": "You can buy",
+    "Exchange_rate": "Exchange rate",
+    "Price": "Price",
+    "Total_earnings": "Total earnings",
+    "Sold_last_week": "Amount sold last week",
+    "Npc": "NPC",
     "Disabled": "The currency spending guide isn't working anymore",
     "Disabled_description": "This is due to Square Enix stopping us from fetching marketboard information. If you want to complain about this, please complain to Square Enix, as there is nothing we can do to make this work without them.",
     "Loading_data": "Loading trades data for the selected currency",
     "Loading_universalis": "Fetching marketboard prices from Universalis for {{amount}} items",
-    "X_sold_last_week": "{{amount}} sold last week",
     "No_trades": "This currency cannot be traded with something that can be sold on marketboard"
   },
   "FOOD_PICKER": {


### PR DESCRIPTION
# Goal
First, make it easier to find the most profitable items to purchase.

The current format does not accomplish because it is sorted by the score. The score does not truly capture the most profitable items to purchase. Higher value items that sell less get penalized, even if all of the items purchased are likely to sell within a week. This makes users less likely to trust the ordering and feel the need to find the highest total value by manually going through all of the items. To that extent, this PR also addresses #3065 .

Second, make it easier to understand the information. This is subjective, but I think tables are better for organized data display. 

# Summary

- Fixup the currency-spending related components to have no warnings with a default typescript environment
- Fix typing in requestsWithDelay to be generic
- Reorganize the currency-spending pipeline into isolated methods
- Rework the currency spending display into a table
- Add additional info to currency spending pipeline
- Allow users to sort currency spending table by numeric columns
- Restrict currency amount entry to minimum of 0

# New Appearance
<img width="2560" height="1250" alt="image" src="https://github.com/user-attachments/assets/4a52d6e9-438e-4922-88fd-c39d0f4f8f25" />


# Todo
[ ] i18n for new column names in currency spending
[ ] Add filters to currency spending for number of items sold last week, access to NPCs, allied society levels
[ ] Create a recommended purchase plan that accounts for market speed. Algorithm likely involves some kind of linear programming