### PR TITLE
Fix: capture signals from linux pcap bridge crashes and show error

### DIFF
--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -3122,11 +3122,11 @@
       "GAME_RUNNING_AS_ADMIN": "Game is running as admin, please either restart it normally or restart Teamcraft as admin.",
       "MISSING_INJECTOR": "Packet capture tooling is missing, most likely removed by your antivirus due to a false positive, make sure to whitelist Teamcraft's install folder and reinstall it.",
       "BRIDGE_PATHS_NOT_CONFIGURED": "One or more required settings for packet capture (Wine/Proton prefix, Wine binary, or FFXIV config directory) are missing. Please change them in Settings.",
-      "BRIDGE_BRIDGE_ERROR": "Check your Wine settings and re-enable packet capture. If the issue persists, check the application logs for more details.",
+      "BRIDGE_CRASHED": "The packet capture bridge crashed unexpectedly. Try using a different version of Wine or Proton, and if you still have issues, please report to discord's #troubleshooting channel.",
       "BRIDGE_GAME_NOT_RUNNING": "Please make sure the game is running before enabling packet capture.<br>If this issue persists, please report to discord's #troubleshooting channel with a screenshot of the above messages."
     },
     "BRIDGE_PATHS_NOT_CONFIGURED": "Wine paths not configured",
-    "BRIDGE_BRIDGE_ERROR": "Packet capture failed to start",
+    "BRIDGE_CRASHED": "Packet capture crashed",
     "BRIDGE_GAME_NOT_RUNNING": "Packet capture failed to start"
   },
   "ISLAND_SANCTUARY": {

--- a/apps/electron/src/pcap/packet-capture.ts
+++ b/apps/electron/src/pcap/packet-capture.ts
@@ -551,14 +551,14 @@ export class PacketCapture {
     this.bridgeProcess.on('exit', (code, signal) => {
       log.info(`[bridge] exited code=${code} signal=${signal}`);
       this.bridgeProcess = null;
-      // code=null means we killed it intentionally (SIGTERM). Any explicit
-      // non-zero exit code means the bridge itself detected an error.
-      if (code !== null && code !== 0 && this.captureInterface) {
+      // We only ever kill the bridge ourselves with the default SIGTERM, so any other
+      // signal (e.g. SIGFPE, SIGSEGV) means it actually crashed, not that we stopped it.
+      if (((code !== null && code !== 0) || (signal !== null && signal !== 'SIGTERM')) && this.captureInterface) {
         log.error(`[bridge] Abnormal exit (stderr: ${stderrBuffer.trim()})`);
         this.store.set('machina', false);
         this.mainWindow.win.webContents.send('toggle-pcap:value', false);
         this.mainWindow.win.webContents.send('pcap:status', 'error');
-        this.mainWindow.win.webContents.send('pcap:error', { message: 'BRIDGE_ERROR' });
+        this.mainWindow.win.webContents.send('pcap:error', { message: 'BRIDGE_CRASHED' });
         this.stop();
       }
     });


### PR DESCRIPTION
I previously only checked the exit code, but crashes don't have an exit code:

```[bridge] exited code=null signal=SIGFPE```