### PR TITLE
fix: update fishing-report miss-type messages

### DIFF
--- a/apps/client/src/app/core/data-reporting/fishing-reporter.ts
+++ b/apps/client/src/app/core/data-reporting/fishing-reporter.ts
@@ -185,10 +185,28 @@ export class FishingReporter implements DataReporter {
     ]).pipe(
       filter(([rodAnimation, playerAnimation]) => {
         /**
-         * 1119: snap?
-         * 1120: Fish left
+         * systemLogMessage types
+         * fisher ignored bite (by waiting):
+         *  bait: 1117
+         *  lure: 1119
+         *
+         * fisher rested bite:
+         *  bait: 1117
+         *  lure: 1119
+         *
+         * hooked but fish slipped:
+         *  bait: 1119
+         *  lure: 1119
+         *
+         * lost your lure: 1118
+         * line snapped: 1120
          */
-        return (rodAnimation.logMessage === 1119 || rodAnimation.logMessage === 1120 ) && Math.abs(rodAnimation.timestamp - playerAnimation.timestamp) < 10000;
+        return (
+          rodAnimation.logMessage === 1117 ||
+          rodAnimation.logMessage === 1118 ||
+          rodAnimation.logMessage === 1119 ||
+          rodAnimation.logMessage === 1120
+        ) && Math.abs(rodAnimation.timestamp - playerAnimation.timestamp) < 10000;
       }),
       map(() => {
         return {
@@ -199,33 +217,12 @@ export class FishingReporter implements DataReporter {
       })
     );
 
-    const resetFromLogMessage$ = packets$.pipe(
-      ofMessageType('systemLogMessage'),
-      toIpcData(),
-      map(packet => {
-        return {
-          logMessage: packet.param1,
-          timestamp: Date.now()
-        };
-      }),
-      filter(rodAnimation => {
-        /**
-         * 1111: Early hook
-         * 1117: Ignored the fish
-         */
-        return rodAnimation.logMessage === 1111 || rodAnimation.logMessage === 1117
-      }),
-      map(() => true)
-    );
-
-    const resetFromAction$ = packets$.pipe(
+    const reset$ = packets$.pipe(
       ofMessageType('eventPlay4'),
       toIpcData(),
       // 271 = fishing idle
       filter(packet => packet.eventId === 0x150001 && packet.params[0] === 271)
     );
-
-    const reset$ = merge(resetFromLogMessage$, resetFromAction$);
 
     const mooch$ = buildMoochState({
       packets$,


### PR DESCRIPTION
add new "miss" messages to the miss filter. in particular moves 1117 (you lost your bait) from reset-type-message to miss-type-message. Also drops resetFromLogMessage$ as 1111 (You put away your rod) serves no purpose.