### PR TITLE
fix(pcap): fix Linux Wine auto-detection for XIVLauncher Proton and Steam compat tool setups

### DIFF
--- a/apps/electron/src/pcap/wine-resolver.ts
+++ b/apps/electron/src/pcap/wine-resolver.ts
@@ -104,7 +104,8 @@ export class WineResolver {
    * standard XIVLauncher and RB_-prefixed keys for the RB fork. Each set
    * has its own WineStartupType. Supported modes:
    *   Custom  – explicit bin directory in WineBinaryPath / RB_WineBinaryPath
-   *   Managed – a named wine build under ~/.xlcore/compatibilitytool/wine/
+   *             (RB: a Proton distribution root is also accepted; its
+   *             standalone wine binary is used, as with Steam's Proton)
    *   Proton  – (RB fork only) a Proton/GE-Proton tool from Steam's
    *             compatibilitytools.d, named in RB_ProtonVersion
    *
@@ -142,12 +143,24 @@ export class WineResolver {
         }
       }
 
-      // 1b. RB Custom mode: explicit binary directory
+      // 1b. RB Custom mode: explicit binary directory. A wine build is
+      // addressed by its bin directory (contains wine/wine64); a Proton
+      // distribution is addressed by its root (contains the `proton`
+      // wrapper), in which case the standalone wine binary lives in the
+      // same layout as Steam's Proton installations.
       if (iniValues['RB_WineStartupType'] === 'Custom' && iniValues['RB_WineBinaryPath']) {
-        const candidate = join(iniValues['RB_WineBinaryPath'], 'wine');
+        const customPath = iniValues['RB_WineBinaryPath'];
+        const candidate = join(customPath, 'wine');
         if (existsSync(candidate)) {
           log.info(`[bridge] Auto-detected Wine from XIVLauncher RB custom config: ${candidate}`);
           return candidate;
+        }
+        if (existsSync(join(customPath, 'proton'))) {
+          const bin = this.findWineBinInProtonDir(customPath);
+          if (bin) {
+            log.info(`[bridge] Auto-detected Wine from XIVLauncher RB custom Proton distro: ${bin}`);
+            return bin;
+          }
         }
       }
 

--- a/apps/electron/src/pcap/wine-resolver.ts
+++ b/apps/electron/src/pcap/wine-resolver.ts
@@ -14,6 +14,11 @@ import { Store } from '../store';
  * once and returns both paths from that same source. This ensures the prefix
  * and binary always come from the same Wine installation.
  *
+ * For XIVLauncher the prefix depends on the wine configuration in
+ * launcher.ini: a Wine prefix (wineprefix) for Wine setups and a Proton
+ * prefix (protonprefix) for Proton setups, mirroring the launcher's own
+ * prefix selection.
+ *
  * User-supplied overrides stored in the Electron store take priority over
  * autodetection for each path independently.
  */
@@ -66,8 +71,13 @@ export class WineResolver {
       if (existsSync(p)) return p;
     }
     if (source === 'xlcore') {
-      const p = join(home, '.xlcore', 'wineprefix');
+      const iniValues = this.readXlcoreIniValues(home);
+      const proton = this.isXlcoreProtonConfig(iniValues);
+      const p = join(home, '.xlcore', proton ? 'protonprefix' : 'wineprefix');
       if (existsSync(p)) return p;
+      if (proton) {
+        log.warn(`[bridge] XIVLauncher is configured for Proton but ~/.xlcore/protonprefix does not exist yet; launch the game through XIVLauncher to create it`);
+      }
     }
     return null;
   }
@@ -108,94 +118,130 @@ export class WineResolver {
    * ~/.xlcore is a symlink to the XDG data directory used by the RB fork
    * (~/.local/share/dev.goats.xivlauncher), so both launchers share the same
    * on-disk wine store and no separate path derivation is needed.
+   *
+   * When the active mode is Proton the matching prefix is
+   * ~/.xlcore/protonprefix instead of ~/.xlcore/wineprefix (see
+   * detectPrefix()), which applies the same mode detection.
    */
   private findXlcoreWineBin(home: string): string | null {
     const wineBaseDir = join(home, '.xlcore', 'compatibilitytool', 'wine');
-    const iniPath = join(home, '.xlcore', 'launcher.ini');
+    const iniValues = this.readXlcoreIniValues(home);
 
-    if (existsSync(iniPath)) {
-      try {
-        const contents = readFileSync(iniPath, 'utf8');
-        const iniValues: Record<string, string> = {};
-        for (const line of contents.split(/\r?\n/)) {
-          const m = line.match(/^([^=]+)=(.+)$/);
-          if (m) iniValues[m[1].trim()] = m[2].trim();
+    // ── RB fork block ─────────────────────────────────────────────────
+    // If RB_WineStartupType is present the user runs the RB fork.
+    // Evaluate all RB_* settings before touching standard keys.
+    if (iniValues['RB_WineStartupType']) {
+      // 1a. RB Proton mode: find the named tool in Steam's compat dirs
+      if (iniValues['RB_WineStartupType'] === 'Proton' && iniValues['RB_ProtonVersion']) {
+        const protonVersion = iniValues['RB_ProtonVersion'];
+        const steamRoot = join(home, '.local', 'share', 'Steam');
+        const bin = this.findProtonWineBinByToolName(steamRoot, protonVersion);
+        if (bin) {
+          log.info(`[bridge] Auto-detected Wine from XIVLauncher RB Proton selection (${protonVersion}): ${bin}`);
+          return bin;
         }
+      }
 
-        // ── RB fork block ─────────────────────────────────────────────────
-        // If RB_WineStartupType is present the user runs the RB fork.
-        // Evaluate all RB_* settings before touching standard keys.
-        if (iniValues['RB_WineStartupType']) {
-          // 1a. RB Proton mode: find the named tool in Steam's compat dirs
-          if (iniValues['RB_WineStartupType'] === 'Proton' && iniValues['RB_ProtonVersion']) {
-            const protonVersion = iniValues['RB_ProtonVersion'];
-            const steamRoot = join(home, '.local', 'share', 'Steam');
-            const bin = this.findProtonWineBinByToolName(steamRoot, protonVersion);
-            if (bin) {
-              log.info(`[bridge] Auto-detected Wine from XIVLauncher RB Proton selection (${protonVersion}): ${bin}`);
-              return bin;
-            }
-          }
-
-          // 1b. RB Custom mode: explicit binary directory
-          if (iniValues['RB_WineStartupType'] === 'Custom' && iniValues['RB_WineBinaryPath']) {
-            const candidate = join(iniValues['RB_WineBinaryPath'], 'wine');
-            if (existsSync(candidate)) {
-              log.info(`[bridge] Auto-detected Wine from XIVLauncher RB custom config: ${candidate}`);
-              return candidate;
-            }
-          }
-
-          // 1c. RB Managed mode: use the version name to find the exact directory.
-          // If the version isn't installed yet (XIVLauncher downloads it on first
-          // game launch), return null rather than silently using a stale version
-          // from a previous session.
-          if (iniValues['RB_WineStartupType'] === 'Managed') {
-            if (iniValues['RB_WineVersion']) {
-              const versionDir = join(wineBaseDir, iniValues['RB_WineVersion']);
-              for (const exe of ['bin/wine64', 'bin/wine']) {
-                const candidate = join(versionDir, exe);
-                if (existsSync(candidate)) {
-                  log.info(`[bridge] Auto-detected Wine from XIVLauncher RB managed version (${iniValues['RB_WineVersion']}): ${candidate}`);
-                  return candidate;
-                }
-              }
-              log.warn(`[bridge] XIVLauncher RB managed wine '${iniValues['RB_WineVersion']}' not installed yet; launch the game through XIVLauncher to download it`);
-              return null;
-            }
-            // No version configured; return null.
-            return null;
-          }
+      // 1b. RB Custom mode: explicit binary directory
+      if (iniValues['RB_WineStartupType'] === 'Custom' && iniValues['RB_WineBinaryPath']) {
+        const candidate = join(iniValues['RB_WineBinaryPath'], 'wine');
+        if (existsSync(candidate)) {
+          log.info(`[bridge] Auto-detected Wine from XIVLauncher RB custom config: ${candidate}`);
+          return candidate;
         }
+      }
 
-        // ── Standard XIVLauncher block ────────────────────────────────────
-        // 2a. Custom mode: explicit binary directory
-        if (iniValues['WineStartupType'] === 'Custom' && iniValues['WineBinaryPath']) {
-          const candidate = join(iniValues['WineBinaryPath'], 'wine');
-          if (existsSync(candidate)) {
-            log.info(`[bridge] Auto-detected Wine from XIVLauncher custom config: ${candidate}`);
-            return candidate;
-          }
-        }
-
-        // 2b. Managed: use the explicitly stored version name
-        if (iniValues['WineManagedVersion']) {
-          const versionDir = join(wineBaseDir, iniValues['WineManagedVersion']);
+      // 1c. RB Managed mode: use the version name to find the exact directory.
+      // If the version isn't installed yet (XIVLauncher downloads it on first
+      // game launch), return null rather than silently using a stale version
+      // from a previous session.
+      if (iniValues['RB_WineStartupType'] === 'Managed') {
+        if (iniValues['RB_WineVersion']) {
+          const versionDir = join(wineBaseDir, iniValues['RB_WineVersion']);
           for (const exe of ['bin/wine64', 'bin/wine']) {
             const candidate = join(versionDir, exe);
             if (existsSync(candidate)) {
-              log.info(`[bridge] Auto-detected Wine from XIVLauncher managed version (${iniValues['WineManagedVersion']}): ${candidate}`);
+              log.info(`[bridge] Auto-detected Wine from XIVLauncher RB managed version (${iniValues['RB_WineVersion']}): ${candidate}`);
               return candidate;
             }
           }
+          log.warn(`[bridge] XIVLauncher RB managed wine '${iniValues['RB_WineVersion']}' not installed yet; launch the game through XIVLauncher to download it`);
+          return null;
         }
-      } catch {
-        // launcher.ini unreadable
+        // No version configured; return null.
+        return null;
+      }
+    }
+
+    // ── Standard XIVLauncher block ────────────────────────────────────
+    // 2a. Custom mode: explicit binary directory
+    if (iniValues['WineStartupType'] === 'Custom' && iniValues['WineBinaryPath']) {
+      const candidate = join(iniValues['WineBinaryPath'], 'wine');
+      if (existsSync(candidate)) {
+        log.info(`[bridge] Auto-detected Wine from XIVLauncher custom config: ${candidate}`);
+        return candidate;
+      }
+    }
+
+    // 2b. Managed: use the explicitly stored version name
+    if (iniValues['WineManagedVersion']) {
+      const versionDir = join(wineBaseDir, iniValues['WineManagedVersion']);
+      for (const exe of ['bin/wine64', 'bin/wine']) {
+        const candidate = join(versionDir, exe);
+        if (existsSync(candidate)) {
+          log.info(`[bridge] Auto-detected Wine from XIVLauncher managed version (${iniValues['WineManagedVersion']}): ${candidate}`);
+          return candidate;
+        }
       }
     }
 
     // Last resort: scan the managed wine directory for the newest version
     return this.scanManagedWineDir(wineBaseDir);
+  }
+
+  /**
+   * Parses ~/.xlcore/launcher.ini into a flat key/value map. Returns an
+   * empty object when the file is missing or unreadable.
+   */
+  private readXlcoreIniValues(home: string): Record<string, string> {
+    const iniPath = join(home, '.xlcore', 'launcher.ini');
+    if (!existsSync(iniPath)) return {};
+    try {
+      const contents = readFileSync(iniPath, 'utf8');
+      const values: Record<string, string> = {};
+      for (const line of contents.split(/\r?\n/)) {
+        const m = line.match(/^([^=]+)=(.+)$/);
+        if (m) values[m[1].trim()] = m[2].trim();
+      }
+      return values;
+    } catch {
+      // launcher.ini unreadable
+      return {};
+    }
+  }
+
+  /**
+   * Whether XIVLauncher will run the game in a Proton prefix (protonprefix)
+   * instead of a Wine prefix (wineprefix). Mirrors the RB fork's own check
+   * in CreateCompatToolsInstance(): the startup type is "Proton", or
+   * "Custom" with a Proton binary path (a "proton" launcher script inside
+   * the configured binary directory). When RB_WineStartupType is absent the
+   * user runs standard XIVLauncher, which has no Proton mode; the
+   * WineStartupType check is a defensive fallback for it.
+   */
+  private isXlcoreProtonConfig(iniValues: Record<string, string>): boolean {
+    if (iniValues['RB_WineStartupType']) {
+      if (iniValues['RB_WineStartupType'] === 'Proton') return true;
+      if (
+        iniValues['RB_WineStartupType'] === 'Custom' &&
+        iniValues['RB_WineBinaryPath'] &&
+        existsSync(join(iniValues['RB_WineBinaryPath'], 'proton'))
+      ) {
+        return true;
+      }
+      return false;
+    }
+    return iniValues['WineStartupType'] === 'Proton';
   }
 
   /**

--- a/apps/electron/src/pcap/wine-resolver.ts
+++ b/apps/electron/src/pcap/wine-resolver.ts
@@ -6,9 +6,12 @@ import { Store } from '../store';
 
 /**
  * Resolves the Wine prefix and binary paths needed to run deucalion-bridge
- * on Linux. Supports two launchers:
+ * on Linux. Supports three configurations:
  *   - Steam (Proton / Proton-GE / custom compat tools)
- *   - XIVLauncher Core (~/.xlcore)
+ *   - XIVLauncher Core (~/.xlcore or ~/.local/share/dev.goats.xivlauncher)
+ *   - XIVLauncher as a Steam compatibility tool (XLM / XLM-RB / the old
+ *     xlcore tool): the game runs in Steam's compatdata prefix, but with
+ *     the Wine/Proton binary from XIVLauncher's own configuration
  *
  * The primary API is resolveWinePaths(), which detects the active launcher
  * once and returns both paths from that same source. This ensures the prefix
@@ -17,7 +20,9 @@ import { Store } from '../store';
  * For XIVLauncher the prefix depends on the wine configuration in
  * launcher.ini: a Wine prefix (wineprefix) for Wine setups and a Proton
  * prefix (protonprefix) for Proton setups, mirroring the launcher's own
- * prefix selection.
+ * prefix selection. In the Steam compatibility tool case the prefix is
+ * Steam's compatdata prefix instead: Steam sets WINEPREFIX/PROTONPREFIX
+ * and the launcher honors them.
  *
  * User-supplied overrides stored in the Electron store take priority over
  * autodetection for each path independently.
@@ -27,16 +32,19 @@ export class WineResolver {
 
   /**
    * Detects which launcher manages the FFXIV Wine environment.
-   * Steam is identified by an initialized Proton prefix for FFXIV (appid 39210),
-   * which only exists after the game has been launched through Steam at least once.
-   * XIVLauncher is identified by the presence of ~/.xlcore.
+   * Steam is identified by an initialized FFXIV compatibility prefix
+   * (compatdata/39210/pfx) in any known Steam installation root, which only
+   * exists after the game has been launched through Steam at least once —
+   * including when XIVLauncher is used as a Steam compatibility tool (XLM),
+   * where the game still runs inside Steam's compatdata prefix.
+   * XIVLauncher is identified by its data directory (~/.xlcore or the XDG
+   * data directory ~/.local/share/dev.goats.xivlauncher).
    * Returns null if neither is found.
    */
   detectAutoSource(): 'steam' | 'xlcore' | null {
     const home = app.getPath('home');
-    const steamPrefix = join(home, '.local', 'share', 'Steam', 'steamapps', 'compatdata', '39210', 'pfx');
-    if (existsSync(steamPrefix)) return 'steam';
-    if (existsSync(join(home, '.xlcore'))) return 'xlcore';
+    if (this.getActiveSteamRoot(home)) return 'steam';
+    if (this.getXlcoreRoot(home)) return 'xlcore';
     return null;
   }
 
@@ -67,30 +75,97 @@ export class WineResolver {
 
   private detectPrefix(source: 'steam' | 'xlcore' | null, home: string): string | null {
     if (source === 'steam') {
-      const p = join(home, '.local', 'share', 'Steam', 'steamapps', 'compatdata', '39210', 'pfx');
-      if (existsSync(p)) return p;
+      const steamRoot = this.getActiveSteamRoot(home);
+      if (!steamRoot) return null;
+      return join(steamRoot, 'steamapps', 'compatdata', '39210', 'pfx');
     }
     if (source === 'xlcore') {
-      const iniValues = this.readXlcoreIniValues(home);
+      const root = this.getXlcoreRoot(home);
+      if (!root) return null;
+      const iniValues = this.readXlcoreIniValues(root);
       const proton = this.isXlcoreProtonConfig(iniValues);
-      const p = join(home, '.xlcore', proton ? 'protonprefix' : 'wineprefix');
+      const p = join(root, proton ? 'protonprefix' : 'wineprefix');
       if (existsSync(p)) return p;
       if (proton) {
-        log.warn(`[bridge] XIVLauncher is configured for Proton but ~/.xlcore/protonprefix does not exist yet; launch the game through XIVLauncher to create it`);
+        log.warn(`[bridge] XIVLauncher is configured for Proton but its protonprefix does not exist yet; launch the game through XIVLauncher to create it`);
       }
     }
     return null;
   }
 
+  /**
+   * Resolves the Wine binary for a detected launcher source.
+   *
+   * The "steam" source has one subtlety: when Steam's configured
+   * compatibility tool for FFXIV is one of the XIVLauncher tools (XLM /
+   * XLM-RB / the old xlcore tool), the game is actually launched by
+   * XIVLauncher. The prefix is still Steam's compatdata prefix (Steam sets
+   * WINEPREFIX/PROTONPREFIX and the launcher honors them), but the Wine
+   * binary is the one from XIVLauncher's own configuration, not Steam's
+   * Proton tool.
+   */
   private detectBin(source: 'steam' | 'xlcore' | null, home: string): string | null {
     if (source === 'steam') {
-      const steamRoot = join(home, '.local', 'share', 'Steam');
+      const steamRoot = this.getActiveSteamRoot(home);
+      if (!steamRoot) return null;
+      const tool = this.readSteamCompatToolForApp(steamRoot, '39210');
+      if (tool && this.isXivLauncherCompatTool(tool)) {
+        log.info(`[bridge] FFXIV runs through the XIVLauncher Steam compat tool '${tool}'; using the launcher's wine configuration`);
+        return this.findXlcoreWineBin(home);
+      }
       return this.findSteamProtonWineBin(steamRoot);
     }
     if (source === 'xlcore') {
       return this.findXlcoreWineBin(home);
     }
     return null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Installation root discovery
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Candidate Steam installation roots, most common first. Native Steam
+   * (e.g. the Arch/Fedora/Debian packages) uses ~/.local/share/Steam;
+   * Steam Deck uses ~/.steam/root.
+   */
+  private getSteamRoots(home: string): string[] {
+    return [join(home, '.local', 'share', 'Steam'), join(home, '.steam', 'root')].filter(existsSync);
+  }
+
+  /**
+   * The Steam root that has an initialized FFXIV compatibility prefix
+   * (steamapps/compatdata/39210/pfx), i.e. the installation the game
+   * actually runs in, or null if none.
+   */
+  private getActiveSteamRoot(home: string): string | null {
+    for (const root of this.getSteamRoots(home)) {
+      if (existsSync(join(root, 'steamapps', 'compatdata', '39210', 'pfx'))) return root;
+    }
+    return null;
+  }
+
+  /**
+   * XIVLauncher's data directory: ~/.xlcore (a symlink or real directory
+   * created by the installers) or the XDG data directory
+   * (~/.local/share/dev.goats.xivlauncher) when there is no ~/.xlcore, e.g.
+   * for XLM Steam compatibility tool installs. Null if neither exists.
+   */
+  private getXlcoreRoot(home: string): string | null {
+    for (const root of [join(home, '.xlcore'), join(home, '.local', 'share', 'dev.goats.xivlauncher')]) {
+      if (existsSync(root)) return root;
+    }
+    return null;
+  }
+
+  /**
+   * Whether a Steam compat tool name (as recorded in config.vdf's
+   * CompatToolMapping) is one of the XIVLauncher tools: XLM ("xlm"), the
+   * XLM RB variant ("xlm-rb"), or the old self-contained tool ("xlcore").
+   */
+  private isXivLauncherCompatTool(toolName: string): boolean {
+    return /^(xlm(-rb)?|xlcore)$/.test(toolName.toLowerCase());
   }
 
   // ---------------------------------------------------------------------------
@@ -118,15 +193,18 @@ export class WineResolver {
    *
    * ~/.xlcore is a symlink to the XDG data directory used by the RB fork
    * (~/.local/share/dev.goats.xivlauncher), so both launchers share the same
-   * on-disk wine store and no separate path derivation is needed.
+   * on-disk wine store; when there is no ~/.xlcore (e.g. XLM compatibility
+   * tool installs) the XDG directory is used directly.
    *
    * When the active mode is Proton the matching prefix is
    * ~/.xlcore/protonprefix instead of ~/.xlcore/wineprefix (see
    * detectPrefix()), which applies the same mode detection.
    */
   private findXlcoreWineBin(home: string): string | null {
-    const wineBaseDir = join(home, '.xlcore', 'compatibilitytool', 'wine');
-    const iniValues = this.readXlcoreIniValues(home);
+    const root = this.getXlcoreRoot(home);
+    if (!root) return null;
+    const wineBaseDir = join(root, 'compatibilitytool', 'wine');
+    const iniValues = this.readXlcoreIniValues(root);
 
     // ── RB fork block ─────────────────────────────────────────────────
     // If RB_WineStartupType is present the user runs the RB fork.
@@ -135,11 +213,12 @@ export class WineResolver {
       // 1a. RB Proton mode: find the named tool in Steam's compat dirs
       if (iniValues['RB_WineStartupType'] === 'Proton' && iniValues['RB_ProtonVersion']) {
         const protonVersion = iniValues['RB_ProtonVersion'];
-        const steamRoot = join(home, '.local', 'share', 'Steam');
-        const bin = this.findProtonWineBinByToolName(steamRoot, protonVersion);
-        if (bin) {
-          log.info(`[bridge] Auto-detected Wine from XIVLauncher RB Proton selection (${protonVersion}): ${bin}`);
-          return bin;
+        for (const steamRoot of this.getSteamRoots(home)) {
+          const bin = this.findProtonWineBinByToolName(steamRoot, protonVersion);
+          if (bin) {
+            log.info(`[bridge] Auto-detected Wine from XIVLauncher RB Proton selection (${protonVersion}): ${bin}`);
+            return bin;
+          }
         }
       }
 
@@ -213,11 +292,12 @@ export class WineResolver {
   }
 
   /**
-   * Parses ~/.xlcore/launcher.ini into a flat key/value map. Returns an
-   * empty object when the file is missing or unreadable.
+   * Parses launcher.ini from XIVLauncher's data directory into a flat
+   * key/value map. Returns an empty object when the file is missing or
+   * unreadable.
    */
-  private readXlcoreIniValues(home: string): Record<string, string> {
-    const iniPath = join(home, '.xlcore', 'launcher.ini');
+  private readXlcoreIniValues(root: string): Record<string, string> {
+    const iniPath = join(root, 'launcher.ini');
     if (!existsSync(iniPath)) return {};
     try {
       const contents = readFileSync(iniPath, 'utf8');


### PR DESCRIPTION
## Summary

Three related bugs in the desktop app's Linux Wine auto-detection, all reported by users in #linux-troubleshooting:

1. **Proton mode picked `wineprefix`.** The `xlcore` prefix detector always returned `~/.xlcore/wineprefix`, ignoring the launcher's Proton configuration. Users running XIVLauncher-RB with Proton (or a custom Proton distribution) got the bridge pointed at their stale Wine prefix.
2. **Custom Proton distros yielded no wine binary.** With XIVLauncher-RB configured with Custom Wine/Proton and pointing at a Proton distribution root (identified by the `proton` wrapper script, same check as the launcher's `IsValidProtonBinaryPath`), detection only looked for `<path>/wine` and failed, leaving the wine binary unset.
3. **XIVLauncher-as-Steam-compat-tool picked Steam's Proton tool.** When XIVLauncher is used as a Steam compatibility tool (XLM / XLM-RB, as documented in the launcher README and recommended for Steam Deck), the game runs in Steam's compatdata prefix (Steam sets `WINEPREFIX`/`PROTONPREFIX` and the launcher honors them) but with the Wine/Proton binary from XIVLauncher's own configuration. Auto-detect resolved the binary from Steam's configured Proton tool instead, so the bridge ran under a different wine than the game.

## Changes

- `detectPrefix()` for the `xlcore` source now mirrors the launcher's own prefix selection: `protonprefix` when `launcher.ini` selects Proton (`RB_WineStartupType=Proton`, or `Custom` with a Proton binary path), `wineprefix` otherwise. If Proton is configured but `protonprefix` doesn't exist yet (game never launched), it returns `null` with a warning instead of silently picking the wrong prefix.
- The RB `Custom` branch now falls back to the distro's standalone wine binary (`files/bin/` or `dist/bin/`, same layout as Steam's Proton installations) when the configured path is a Proton distribution root.
- `detectBin()` for the `steam` source reads the compatibility tool Steam has configured for FFXIV (`config.vdf` `CompatToolMapping`); when it is a XIVLauncher tool (`xlm`, `xlm-rb`, or the old `xlcore` tool), the binary is resolved from the launcher's `launcher.ini` while the prefix stays Steam's compatdata prefix.
- Steam installations are now discovered in both native (`~/.local/share/Steam`) and Steam Deck (`~/.steam/root`) roots, using the root that actually has the FFXIV compat prefix.
- The launcher data directory is found via `~/.xlcore` or, when absent (XLM compat-tool installs don't create that symlink), the XDG data directory `~/.local/share/dev.goats.xivlauncher`.
- The `launcher.ini` parse is shared between prefix and binary detection (`readXlcoreIniValues()`); binary-detection behavior is unchanged.