### PR TITLE
fix(allagan-reports): For oceanfishing, Allagan Reports editor showing all weathers is helpful

### DIFF
--- a/apps/client/src/app/pages/allagan-reports/allagan-report-details/allagan-report-details.component.ts
+++ b/apps/client/src/app/pages/allagan-reports/allagan-report-details/allagan-report-details.component.ts
@@ -8,7 +8,7 @@ import { I18nToolsService } from '../../../core/tools/i18n-tools.service';
 import { AllaganReport } from '../model/allagan-report';
 import { NzMessageService } from 'ng-zorro-antd/message';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { pickBy, uniq } from 'lodash';
+import { pickBy, uniq, uniqBy } from 'lodash';
 import { AuthFacade } from '../../../+state/auth.facade';
 import { AllaganReportQueueEntry } from '../model/allagan-report-queue-entry';
 import { AllaganReportStatus } from '../model/allagan-report-status';
@@ -264,10 +264,22 @@ export class AllaganReportDetailsComponent extends ReportsManagementComponent {
     startWith([])
   );
 
-  public mapWeathers$ = this.fishingSpot$.pipe(
-    filter(spot => !!spot),
-    map((spot) => {
-      return uniq((weatherIndex[mapIds.find(m => m.id === spot.mapId).weatherRate] || []).map(row => +row.weatherId)) as number[];
+  public mapWeathers$ = this.isOceanFishing$.pipe(
+    switchMap(isOceanFishing => {
+      if (isOceanFishing) {
+        return this.lazyData.getEntry('weathers').pipe(
+          map(weathers => {
+            const ids = Object.keys(weathers).map(Number);
+            return uniqBy(ids, id => this.i18n.getName(weathers[id].name));
+          })
+        );
+      }
+      return this.fishingSpot$.pipe(
+        filter(spot => !!spot),
+        map((spot) => {
+          return uniq((weatherIndex[mapIds.find(m => m.id === spot.mapId).weatherRate] || []).map(row => +row.weatherId)) as number[];
+        })
+      );
     }),
     shareReplay({ bufferSize: 1, refCount: true })
   );


### PR DESCRIPTION
Hello TC maintainers - thanks as always for your help.

Today I have a small adjustment to address a deficiency in the Weathers picker in the Allagan Reports editor specifically for Ocean Fishing fish.

Ocean Fishing's weather works differently from the normal game, and currently basing this selection on the game's data files leads to a list that does not contain all of the weathers that can occur in ocean fishing (on either route). It's just showing Limsa's weather as a placeholder.

I tried to think of a more elegant solution but nothing appeared to me w/o making much larger changes, so what I have is simply showing all weathers, which are already loaded into LazyWeathers. Many of the choices are nonsensical, but the point is that editors/approvers would now have the ability to list the real weathers for ocean fish.

I tested this locally (with allagan reports real database) and it seemed to work okay.

Non oceanfishing fish should not be affected.

Thank you for your review!