### PR TITLE
fix(fishing-reporter): toggling the eorzean date format toggles fishing cast format

### DIFF
--- a/apps/client/src/app/pages/fishing-reporter-overlay/fishing-reporter-overlay/fishing-reporter-overlay.component.html
+++ b/apps/client/src/app/pages/fishing-reporter-overlay/fishing-reporter-overlay/fishing-reporter-overlay.component.html
@@ -39,7 +39,11 @@
         </div>
         <div fxLayout="row" fxLayoutAlign="space-between center">
           <div>{{'DB.FISH.OVERLAY.Throw_etime' | translate}}</div>
-          <div>{{throwTime$ | async | date:'hh:mm:ss':'UTC'}}</div>
+            @if (settings.timeFormat == '12H') {
+              <div>{{throwTime$ | async | date:'hh:mm:ss a':'UTC'}}</div>
+            } @else {
+              <div>{{throwTime$ | async | date:'HH:mm:ss':'UTC'}}</div>
+            }
         </div>
         <div fxLayout="row" fxLayoutAlign="space-between center">
           <div>{{'DB.FISH.OVERLAY.Time_since_thrown' | translate}}</div>

--- a/apps/client/src/app/pages/fishing-reporter-overlay/fishing-reporter-overlay/fishing-reporter-overlay.component.html
+++ b/apps/client/src/app/pages/fishing-reporter-overlay/fishing-reporter-overlay/fishing-reporter-overlay.component.html
@@ -39,7 +39,7 @@
         </div>
         <div fxLayout="row" fxLayoutAlign="space-between center">
           <div>{{'DB.FISH.OVERLAY.Throw_etime' | translate}}</div>
-            @if (settings.timeFormat == '12H') {
+            @if (settings.timeFormat === '12H') {
               <div>{{throwTime$ | async | date:'hh:mm:ss a':'UTC'}}</div>
             } @else {
               <div>{{throwTime$ | async | date:'HH:mm:ss':'UTC'}}</div>

--- a/apps/client/src/app/pages/fishing-reporter-overlay/fishing-reporter-overlay/fishing-reporter-overlay.component.ts
+++ b/apps/client/src/app/pages/fishing-reporter-overlay/fishing-reporter-overlay/fishing-reporter-overlay.component.ts
@@ -22,6 +22,7 @@ import { NzAlertModule } from 'ng-zorro-antd/alert';
 import { FlexModule } from '@angular/flex-layout/flex';
 import { AsyncPipe, DecimalPipe, DatePipe } from '@angular/common';
 import { OverlayContainerComponent } from '../../../modules/overlay-container/overlay-container/overlay-container.component';
+import { SettingsService } from '../../../modules/settings/settings.service';
 
 @Component({
     selector: 'app-fishing-reporter-overlay',
@@ -64,7 +65,7 @@ export class FishingReporterOverlayComponent {
     map(state => state.spot?.id >= 10000)
   );
 
-  constructor(private ipc: IpcService, private translate: TranslateService) {
+  constructor(private ipc: IpcService, private translate: TranslateService, public settings: SettingsService) {
     this.ipc.on('fishing-state', (event, data) => {
       this.state$.next(data);
     });


### PR DESCRIPTION
Clicking on the eorzean time of the main teamcraft window or the clock at the bottom of the fishing reporter footer will now toggle the "throw etime" display from 12/24 hr formats.