### PR TITLE
Update fishing reports to use packet header timestamps

### DIFF
--- a/apps/client/src/app/core/data-reporting/fishing-reporter.ts
+++ b/apps/client/src/app/core/data-reporting/fishing-reporter.ts
@@ -119,17 +119,16 @@ export class FishingReporter implements DataReporter {
 
     const throw$ = packets$.pipe(
       ofMessageType('eventPlay4'),
-      toIpcData(),
-      filter(packet => packet.eventId === 0x150001 && packet.scene === 1),
+      filter(packet => packet.parsedIpcData.eventId === 0x150001 && packet.parsedIpcData.scene === 1),
       delay(200),
       withLatestFrom(
         this.eorzea.statuses$,
         this.eorzea.weatherId$,
         this.eorzea.previousWeatherId$
       ),
-      map(([, statuses, weatherId, previousWeatherId]) => {
+      map(([packet, statuses, weatherId, previousWeatherId]) => {
         return {
-          timestamp: Date.now(),
+          timestamp: parseInt(packet.header.ipcTimestamp),
           etime: this.etime.toEorzeanDate(new Date()),
           statuses,
           weatherId,
@@ -138,14 +137,15 @@ export class FishingReporter implements DataReporter {
       })
     );
 
-
-    const bite$ = eventPlay$.pipe(
-      filter(packet => packet.scene === 5),
+    const bite$ = packets$.pipe(
+      ofMessageType('eventPlay'),
+      filter(packet => packet.parsedIpcData.eventId === 0x150001),
+      filter(packet => packet.parsedIpcData.scene === 5),
       withLatestFrom(this.eorzea.statuses$),
       map(([packet, statuses]) => {
         return {
-          timestamp: Date.now(),
-          tug: this.getTug(packet.param5),
+          timestamp: parseInt(packet.header.ipcTimestamp),
+          tug: this.getTug(packet.parsedIpcData.param5),
           statuses
         };
       })
@@ -183,11 +183,10 @@ export class FishingReporter implements DataReporter {
     const misses$ = combineLatest([
       packets$.pipe(
         ofMessageType('systemLogMessage'),
-        toIpcData(),
         map(packet => {
           return {
-            logMessage: packet.param1,
-            timestamp: Date.now()
+            logMessage: packet.parsedIpcData.param1,
+            timestamp: parseInt(packet.header.ipcTimestamp)
           };
         })
       ),

--- a/apps/client/src/app/core/data-reporting/fishing-reporter.ts
+++ b/apps/client/src/app/core/data-reporting/fishing-reporter.ts
@@ -53,7 +53,7 @@ export class FishingReporter implements DataReporter {
       map(packet => {
         return {
           id: packet.itemId,
-          hq: (packet.flags >> 6 & 1) === 1,
+          hq: (packet.flags >> 4 & 1) === 1,
           moochable: (packet.flags & 5) === 5,
           size: packet.size
         };

--- a/apps/client/src/app/pages/fishing-reporter-overlay/fishing-reporter-overlay/fishing-reporter-overlay.component.ts
+++ b/apps/client/src/app/pages/fishing-reporter-overlay/fishing-reporter-overlay/fishing-reporter-overlay.component.ts
@@ -43,7 +43,10 @@ export class FishingReporterOverlayComponent {
       }
       // If they threw but no bite yet
       if (!state.biteData || state.throwData.timestamp > state.biteData.timestamp) {
-        return Math.floor((Date.now() - state.throwData.timestamp) / 1000);
+        const time_since = Math.floor((Date.now() - state.throwData.timestamp) / 1000);
+        // because cast-time is always floored, extremely small negative values display as -1 entire seconds
+        // let's just say 0 for those
+        return time_since < 0 ? 0 : time_since
       }
       // If they threw and bite happened
       return Math.floor((state.biteData.timestamp - state.throwData.timestamp) / 1000);


### PR DESCRIPTION
Problem: 
Teamcraft pcap values for fish times aren't always accurate.

Proposed cause: 
Teamcraft records fish-bite and -throw times with `Date.now()`. This means the times are recorded as "whatever time it is whenever TC gets around to consuming packets." If TC lags, such as when opening a fishing-hole page, those times may vary.

Proposed solution: 
Changing the timestamp to use the packet IPC timestamp means TC will get the time the packet was created instead.

I tested this fix by opening a separate instance of pcap (https://github.com/ffxiv-teamcraft/pcap-ffxiv) alongside a dev copy of teamcraft. While opening a fishing hole on the dev copy, I observed the pcap reported 20:33:12.434Z; ten seconds later (20:33:22.877Z) the lagging TC caught up and reported the same timestamp (20:33:12.434Z).

In addition, I checked that the difference in bite-times were not dissimilar after the update. I caught 15 fish on prod and 15 on dev to compare, with the corresponding GB records for reference.

fish | throwtime - tc | throwtime - gb | tc type | diff | type
-- | -- | -- | -- | -- | --
brass loach | 13.4 | 13.6 | prod | -0.2 | lure
silverfish | 14.8 | 15 | prod | -0.2 | lure
goldfish | 18 | 18.3 | prod | -0.3 | mooch
silverfish | 13.5 | 13.8 | prod | -0.3 | lure
silverfish | 14 | 14.4 | prod | -0.4 | lure
silverfish | 15.5 | 15.7 | prod | -0.2 | lure
copperfish | 15.7 | 16 | prod | -0.3 | lure
copperfish | 15.5 | 15.8 | prod | -0.3 | lure
silverfish | 12 | 12.3 | prod | -0.3 | bait
goldfish | 13.9 | 14.2 | prod | -0.3 | mooch
silverfish | 8 | 8.4 | prod | -0.4 | bait
faerie bass | 17.7 | 18.1 | prod | -0.4 | bait
copperfish | 17.6 | 17.8 | prod | -0.2 | bait
brass loach | 14 | 14.2 | prod | -0.2 | bait
copperfish | 16.3 | 16.6 | prod | -0.3 | bait
dark bass | 16.8 | 16.8 | dev | 0 | lure
faerie bass | 13.5 | 13.6 | dev | -0.1 | lure
copperfish | 11.1 | 11.2 | dev | -0.1 | lure
eunuch crayfish | 14.3 | 14.4 | dev | -0.1 | mooch
copperfish | 15.8 | 15.8 | dev | 0 | lure
copperfish | 12.9 | 12.9 | dev | 0 | lure
copperfish | 18.3 | 18.4 | dev | -0.1 | bait
silverfish | 11.8 | 11.9 | dev | -0.1 | bait
goldfish | 13.3 | 13.4 | dev | -0.1 | swimbait
silverfish | 7.6 | 7.7 | dev | -0.1 | bait
copperfish | 16.9 | 17 | dev | -0.1 | bait
brass loach | 16.3 | 16.4 | dev | -0.1 | bait
faerie bass | 16.3 | 16.5 | dev | -0.2 | bait