### PR TITLE
feat/fix (simulator): Added chooser Dialog

### DIFF
--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.html
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.html
@@ -1,40 +1,35 @@
 <div fxLayout="column" fxLayoutGap="10px">
-  @if (running) {
-    <div fxLayout="column" fxLayoutGap="5px">
-      <div>{{ 'SIMULATOR.SOLVER.Searching' | translate }} ({{ 'SIMULATOR.SOLVER.Depth' | translate }}: {{ depth }})</div>
-      <nz-progress [nzPercent]="bestQuality / recipe.quality * 100" [nzFormat]="progressFormat()"></nz-progress>
-      @if (qualityComplete) {
-        <nz-tag [nzColor]="'green'">{{ 'SIMULATOR.SOLVER.Quality_maxed' | translate }}</nz-tag>
-      }
-      @if (bestSuccess) {
-        <div>{{ 'SIMULATOR.SOLVER.Valid_rotation_found' | translate }}</div>
-      }
-    </div>
-  } @else {
+  @if (phase === 'selection') {
     <div fxLayout="column" fxLayoutGap="10px">
-      <div>{{ 'SIMULATOR.SOLVER.Done' | translate }}</div>
-      @if (reliability) {
-        <div fxLayout="row wrap" fxLayoutGap="10px">
-          <nz-tag [nzColor]="'geekblue'">
-            {{ 'SIMULATOR.Reliability' | translate }}: {{ reliability.successPercent }}%
-          </nz-tag>
-          <nz-tag [nzColor]="'purple'">
-            {{ 'SIMULATOR.Average_hq' | translate }}: {{ reliability.averageHQPercent }}%
-          </nz-tag>
+      <div>{{ 'SIMULATOR.SOLVER.Select_actions_hint' | translate }}</div>
+
+      @for (category of categories; track category.titleKey) {
+        <div fxLayout="column" fxLayoutGap="5px">
+          <h4>{{ category.titleKey | translate }}</h4>
+          <div fxLayout="row wrap" fxLayoutGap="10px">
+            @for (action of category.actions; track action.getIds()[0]) {
+              <div class="action-toggle"
+                    [class.locked]="isLevelLocked(action)"
+                    (click)="toggleAction(action)">
+                <app-action
+                    [action]="action"
+                    [hideCost]="true"
+                    [disabled]="isLevelLocked(action)"
+                    [safe]="isEnabled(action) || isLevelLocked(action)"
+                    [ignoreDisabled]="false"
+                    [tooltipDisabled]="false"></app-action>
+                @if (isEnabled(action) && !isLevelLocked(action)) {
+                  <i nz-icon nzType="check-circle" nzTheme="twotone" [nzTwotoneColor]="'#52c41a'" class="toggle-icon"></i>
+                }
+              </div>
+            }
+          </div>
         </div>
       }
-      <div fxLayout="row wrap" fxLayoutGap="10px">
-        @for (action of resultActions; track $index) {
-          <app-action [action]="action" [hideCost]="true"></app-action>
-        }
-      </div>
-      <button (click)="apply()" nz-button nzType="primary">
-        {{ 'SIMULATOR.SOLVER.Apply' | translate }}
+
+      <button (click)="startSolving()" nz-button nzType="primary" nzBlock>
+        {{ 'SIMULATOR.SOLVER.Start' | translate }}
       </button>
     </div>
-  }
-
-  @if (error) {
-    <div style="color: red;">{{ errorMessage }}</div>
   }
 </div>

--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.html
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.html
@@ -32,4 +32,46 @@
       </button>
     </div>
   }
+
+  @if (phase === 'running') {
+    <div fxLayout="column" fxLayoutGap="5px">
+      <div>{{ 'SIMULATOR.SOLVER.Searching' | translate }}</div>
+      <nz-progress [nzPercent]="bestQuality / recipe.quality * 100"
+          [nzFormat]="progressFormat()"></nz-progress>
+      @if (qualityComplete) {
+        <nz-tag [nzColor]="'green'">{{ 'SIMULATOR.SOLVER.Quality_maxed' | translate}}</nz-tag>
+      }
+      @if (bestSuccess) {
+        <div>{{ 'SIMULATION.SOLVER.Valid_rotation_found' | translate }}</div>
+      }
+    </div>
+  }
+
+  @if (phase === 'done') {
+    <div fxLayout="column" fxLayoutGap="10px">
+      <div>{{ 'SIMULATOR.SOLVER.Done' | translate }}</div>
+      @if (reliablity) {
+        <div fxLayout="row wrap" fxLayoutGap="10px">
+          <nz-tag [nzColor]="'geekblue'">
+            {{ 'SIMULATOR.Reliablity' | translate}}: {{ reliablity.successPercent }}
+          </nz-tag>
+          <nz-tag [nzColor]="'purple'">
+            {{ 'SIMULATOR.Average_hq' | translate }}: {{ reliablity.averageHQPercent}}
+          </nz-tag>
+        </div>
+      }
+      <div fxLayout="row wrap" fxLayoutGap="10px">
+        @for (action of resultActions; track $index) {
+          <app-action [action]="action" [hideCost]="true"></app-action>
+        }
+      </div>
+      <button (click)="apply()" nz-button nzType="primary">
+        {{ 'SIMULATOR.SOLVER.Apply' | translate }}
+      </button>
+    </div>
+  }
+
+  @if (error) {
+    <div class="error-message">{{ errorMessage }}</div>
+  }
 </div>

--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.html
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.html
@@ -34,16 +34,9 @@
   }
 
   @if (phase === 'running') {
-    <div fxLayout="column" fxLayoutGap="5px">
-      <div>{{ 'SIMULATOR.SOLVER.Searching' | translate }}</div>
-      <nz-progress [nzPercent]="bestQuality / recipe.quality * 100"
-          [nzFormat]="progressFormat()"></nz-progress>
-      @if (qualityComplete) {
-        <nz-tag [nzColor]="'green'">{{ 'SIMULATOR.SOLVER.Quality_maxed' | translate}}</nz-tag>
-      }
-      @if (bestSuccess) {
-        <div>{{ 'SIMULATION.SOLVER.Valid_rotation_found' | translate }}</div>
-      }
+    <div class="running-container" fxLayout="column" fxLayoutAlign="center center" fxLayoutGap="15px">
+      <nz-spin nzSize="large"></nz-spin>
+      <div class="running-hint">{{ 'SIMULATOR.SOLVER.Searching_indeterminate' | translate }}</div>
     </div>
   }
 

--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.less
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.less
@@ -1,3 +1,26 @@
 nz-progress {
   width: 100%;
 }
+
+.action-toggle {
+  position: relative;
+  cursor: pointer;
+
+  &.locked {
+    cursor: not-allowed;
+  }
+
+  .toggle-icon {
+    position: absolute;
+    bottom: -6px;
+    right: -6px;
+    z-index: 5;
+    font-size: 16px;
+    background: #1f1f1f;
+    border-radius: 50%;
+  }
+}
+
+.error-message {
+  color: red;
+}

--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.less
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.less
@@ -21,6 +21,17 @@ nz-progress {
   }
 }
 
+.running-container {
+  min-height: 160px;
+  padding: 20px;
+}
+
+.running-hint {
+  text-align: center;
+  opacity: 0.8;
+  max-width: 320px;
+}
+
 .error-message {
   color: red;
 }

--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
@@ -13,6 +13,7 @@ import { NzTagModule } from "ng-zorro-antd/tag";
 import { SimulationReliabilityReport, SimulationService } from "../../../../core/simulation/simulation.service";
 import { ActionCategory } from '../../model/action-category';
 import { SettingsService } from "apps/client/src/app/modules/settings/settings.service";
+import { NzIconModule } from "ng-zorro-antd/icon";
 
 /**
  * Class names (as reported by `action.constructor.name`) of Cosmic Exploration-only
@@ -51,6 +52,7 @@ type SolverPhase = 'selection' | 'running' | 'done';
     NzProgressModule,
     NzButtonModule,
     NzTagModule,
+    NzIconModule,
     TranslateModule,
     ActionComponent
   ]

--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
@@ -28,6 +28,16 @@ const COSMIC_EXPLORATION_ACTION_NAMES = new Set<string>(['MaterialMiracle2', 'St
  */
 const SPECIALIST_ACTION_NAMES = new Set<string>(['CarefulObservation2', 'HeartAndSoul2', 'QuickInnovation2']);
 
+/**
+ * Class names of actions, that are technically safe by the recipe's starting-state
+ * check, but rely on random crafting conditions (e.g. "Good"/"Excellent") to actually be
+ * used reiably in practice. Excluded from the default selection, but still manually selectable
+ * by the user
+ */
+const DEFAULT_EXCLUDED_UNRELIABLE_ACTION_NAMES = new Set<string>([
+  'TricksOfTheTrade2'
+]);
+
 /** The three high-level phases the popup walks through. */
 type SolverPhase = 'selection' | 'running' | 'done';
 
@@ -155,12 +165,21 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
    * Cosmic Exploration and Specialist actions, which are opt-in only.
    */
   private initializeDefaultSelection(): void {
+    const sim = new this.simulator.Simulation(this.recipe, [], this.stats, this.hqIngredients);
+    const baselineResult = sim.run(true, Infinity, true);
+    const baselineSimulation = baselineResult.simulation;
+    
     for (const category of this.categories) {
       for (const action of category.actions) {
         if (this.isLevelLocked(action)) continue;
+
         const name = this.actionName(action);
         if (COSMIC_EXPLORATION_ACTION_NAMES.has(name)) continue;
         if (SPECIALIST_ACTION_NAMES.has(name)) continue;
+        if (DEFAULT_EXCLUDED_UNRELIABLE_ACTION_NAMES.has(name)) continue;
+
+        if ((action as any).getSuccessRate?.(baselineSimulation) < 100) continue;
+
         this.selectedActionNames.add(name);
       }
     }
@@ -218,19 +237,20 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
         )
         .subscribe({
           next: ({ progress, result, reliablity }) => {
-           if (progress) {
-            this.depth = progress.depth;
-            this.bestQuality = progress.bestQuality;
-            this.bestSuccess = progress.bestSuccess;
-            this.qualityComplete = progress.qualityComplete;
-           } 
-           if (result) {
-            this.resultActions = result;
-            this.reliablity = reliablity;
-            this.running = false;
-            this.phase = 'done';
-           }
-           this.cd.markForCheck();
+            console.log('[SolverPopupComponent] event received', { progress, result });
+            if (progress) {
+              this.depth = progress.depth;
+              this.bestQuality = progress.bestQuality;
+              this.bestSuccess = progress.bestSuccess;
+              this.qualityComplete = progress.qualityComplete;
+            } 
+            if (result) {
+              this.resultActions = result;
+              this.reliablity = reliablity;
+              this.running = false;
+              this.phase = 'done';
+            }
+            this.cd.markForCheck();
           },
           error: (err) => {
             this.error = true;

--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
@@ -10,7 +10,26 @@ import { Subscription } from "rxjs";
 import { SolverService } from "../../service/solver.service";
 import { NzModalRef } from "ng-zorro-antd/modal";
 import { NzTagModule } from "ng-zorro-antd/tag";
-import { SimulationReliabilityReport } from "../../../../core/simulation/simulation.service";
+import { SimulationReliabilityReport, SimulationService } from "../../../../core/simulation/simulation.service";
+import { ActionCategory } from '../../model/action-category';
+import { SettingsService } from "apps/client/src/app/modules/settings/settings.service";
+
+/**
+ * Class names (as reported by `action.constructor.name`) of Cosmic Exploration-only
+ * actions, excluded from the default selection since they only apply to a small
+ * subset of recipes. Kept in sync with the same list in `solver-core.ts`.
+ */
+const COSMIC_EXPLORATION_ACTION_NAMES = new Set<string>(['MaterialMiracle2', 'StellarSteadyHand2']);
+
+/**
+ * Class names of Specialist-only actions, excluded from the default selection.
+ * Kept in sync with the same list in `solver-core.ts`.
+ */
+const SPECIALIST_ACTION_NAMES = new Set<string>(['CarefulObservation2', 'HeartAndSoul2', 'QuickInnovation2']);
+
+/** The three high-level phases the popup walks through. */
+type SolverPhase = 'selection' | 'running' | 'done';
+
 
 /**
  * Modal popup that runs the crafting rotation solver for the currently configured
@@ -51,19 +70,13 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
   /** Search time budget (ms) passed to {@link SolverService.solve} */
   maxComputeMs = 58000;
 
-  /**
-   * Whether Cosmic Exploration-only actions may be used by the solver. Reserved for
-   * future UI toggle. Defaults to false since these actions only apply to a small
-   * subset of recipes and are not available under normal circumstances
-   */
-  shouldUseCosmicExploration = false;
+  /** Which step of the popup is currently shown */
+  phase: SolverPhase = 'selection';
 
-  /**
-   * Whether Specialist-only actions may be used by the solver. Reserved for a future UI
-   * toggle. Defaults to false. Even when true, these actions are only actually considered by
-   * the solver if 'stats.specialist' is also true (see {@link SolverService.solve})
-   */
-  shouldUseSpecialistCommands = false;
+  /** Actions grouped by category for the selection grid, build in {@link ngOnInit} */
+  categories: ActionCategory[] = [];
+  /** Class names of actions the user has enabled for the solver to use */
+  selectedActionNames = new Set<string>()
 
   /** Whether the solver is currently still searching */
   running = true;
@@ -89,9 +102,15 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
   private solver: SolverService = inject(SolverService);
   private modalRef: NzModalRef = inject(NzModalRef);
   private cd: ChangeDetectorRef = inject(ChangeDetectorRef);
+  private simulationService: SimulationService = inject(SimulationService);
+  private settings: SettingsService = inject(SettingsService);
 
   constructor() {
     super();
+  }
+
+  private get simulator() {
+    return this.simulationService.getSimulator(this.settings.region);
   }
 
   /**
@@ -102,38 +121,122 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
    */
   ngOnInit(): void {
     this.patchData();
-    this.sub = this.solver.solve(
-      this.recipe,
-      this.stats,
-      this.hqIngredients,
-      this.beamWidth,
-      this.maxSteps,
-      this.maxComputeMs,
-      this.shouldUseCosmicExploration,
-      this.shouldUseSpecialistCommands
-    ).subscribe({
-      next: ({ progress, result, reliablity }) => {
-        if (progress) {
-          this.depth = progress.depth;
-          this.bestQuality = progress.bestQuality;
-          this.bestSuccess = progress.bestSuccess;
-          this.qualityComplete = progress.qualityComplete;
-        }
-        if (result) {
-          this.resultActions = result;
-          this.reliablity = reliablity;
-          this.running = false;
-        }
-        this.cd.markForCheck();
+    this.buildCategories();
+    this.initializeDefaultSelection();
+  }
+
+  /**
+   * Builds the categorized action list shown in the selection grid, mirroring the category
+   * breakdown used in the main simulator UI.
+   */
+  private buildCategories(): void {
+    const registry = this.simulator.CraftingActionsRegistry;
+    const ActionType = this.simulator.ActionType;
+
+    this.categories = [
+      { titleKey: 'SIMULATOR.CATEGORY.Progression', actions: registry.getActionsByType(ActionType.PROGRESSION) },
+      { titleKey: 'SIMULATOR.CATEGORY.Quality', actions: registry.getActionsByType(ActionType.QUALITY) },
+      { titleKey: 'SIMULATOR.CATEGORY.Buff', actions: registry.getActionsByType(ActionType.BUFF) },
+      { titleKey: 'SIMULATOR.CATEGORY.Repair', actions: registry.getActionsByType(ActionType.REPAIR) },
+      { 
+        titleKey: 'SIMULATOR.CATEGORY.Other',
+        actions: [
+          ...registry.getActionsByType(ActionType.OTHER),
+          ...registry.getActionsByType(ActionType.CP_RECOVERY)
+        ]
       },
-      error: (err) => {
-        console.error('[SolverPopupComponent] error', err);
-        this.error = true;
-        this.errorMessage = err?.message ?? String(err);
-        this.running = false;
-        this.cd.markForCheck();
+    ];
+  }
+
+  /**
+   * Selects every action that is available at the crafter's level by default, except
+   * Cosmic Exploration and Specialist actions, which are opt-in only.
+   */
+  private initializeDefaultSelection(): void {
+    for (const category of this.categories) {
+      for (const action of category.actions) {
+        if (this.isLevelLocked(action)) continue;
+        const name = this.actionName(action);
+        if (COSMIC_EXPLORATION_ACTION_NAMES.has(name)) continue;
+        if (SPECIALIST_ACTION_NAMES.has(name)) continue;
+        this.selectedActionNames.add(name);
       }
-    });
+    }
+  }
+
+  /**
+   * Wheter the crafter's level is too low to ever use this action, regardles of
+   * solver selection.
+   * @param action The Action to check for level requirement
+   */
+  isLevelLocked(action: CraftingAction): boolean {
+    const requirement = (action as any).getLevelRequirement();
+    const CraftingJob = this.simulator.CraftingJob;
+    if (requirement.job !== CraftingJob.ANY && this.stats.levels?.[requirement.job] !== undefined)
+      return this.stats.levels[requirement.job] < requirement.level;
+
+    return this.stats.level < requirement.level;
+  }
+
+  /** Wheter the given action is currently selected for the solver to use */
+  isEnabled(action: CraftingAction): boolean {
+    return this.selectedActionNames.has(this.actionName(action));
+  }
+
+  /** Toggles an action's inclusion in the solver's candidate pool. No-op for level-locked */
+  toggleAction(action: CraftingAction): void {
+    if (this.isLevelLocked(action)) return;
+    const name = this.actionName(action);
+    if (this.selectedActionNames.has(name))
+      this.selectedActionNames.delete(name);
+    else
+      this.selectedActionNames.add(name);
+
+    this.cd.markForCheck();
+  }
+
+  /** Returns the name of the Action */
+  private actionName(action: CraftingAction): string {
+    return (action as any).constructor?.name;
+  }
+
+  /** Advances from the selection step to actually running the solver */
+  startSolving(): void {
+    this.phase = 'running';
+    this.running = true;
+    this.sub = this.solver
+        .solve(
+          this.recipe,
+          this.stats,
+          this.hqIngredients,
+          this.beamWidth,
+          this.maxSteps,
+          this.maxComputeMs,
+          [...this.selectedActionNames]
+        )
+        .subscribe({
+          next: ({ progress, result, reliablity }) => {
+           if (progress) {
+            this.depth = progress.depth;
+            this.bestQuality = progress.bestQuality;
+            this.bestSuccess = progress.bestSuccess;
+            this.qualityComplete = progress.qualityComplete;
+           } 
+           if (result) {
+            this.resultActions = result;
+            this.reliablity = reliablity;
+            this.running = false;
+            this.phase = 'done';
+           }
+           this.cd.markForCheck();
+          },
+          error: (err) => {
+            this.error = true;
+            this.errorMessage = err?.message ?? String(err);
+            this.running = false;
+            this.cd.markForCheck();
+          }
+        });
   }
 
   /** Closes the modal, returning the found rotation to the caller (e.g. the simulator) */

--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
@@ -11,7 +11,7 @@ import { NzModalRef } from "ng-zorro-antd/modal";
 import { NzTagModule } from "ng-zorro-antd/tag";
 import { SimulationReliabilityReport, SimulationService } from "../../../../core/simulation/simulation.service";
 import { ActionCategory } from '../../model/action-category';
-import { SettingsService } from "apps/client/src/app/modules/settings/settings.service";
+import { SettingsService } from '../../../../modules/settings/settings.service';
 import { NzIconModule } from "ng-zorro-antd/icon";
 import { NzSpinModule } from "ng-zorro-antd/spin";
 

--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnDestro
 import { FlexModule } from "@angular/flex-layout";
 import { TranslateModule } from "@ngx-translate/core";
 import { NzButtonModule } from "ng-zorro-antd/button";
-import { NzProgressModule } from "ng-zorro-antd/progress";
 import { ActionComponent } from "../action/action.component";
 import { DialogComponent } from "../../../../../app/core/dialog.component";
 import { Craft, CraftingAction, CrafterStats } from "@ffxiv-teamcraft/simulator";
@@ -14,6 +13,7 @@ import { SimulationReliabilityReport, SimulationService } from "../../../../core
 import { ActionCategory } from '../../model/action-category';
 import { SettingsService } from "apps/client/src/app/modules/settings/settings.service";
 import { NzIconModule } from "ng-zorro-antd/icon";
+import { NzSpinModule } from "ng-zorro-antd/spin";
 
 /**
  * Class names (as reported by `action.constructor.name`) of Cosmic Exploration-only
@@ -59,10 +59,10 @@ type SolverPhase = 'selection' | 'running' | 'done';
   standalone: true,
   imports: [
     FlexModule,
-    NzProgressModule,
     NzButtonModule,
     NzTagModule,
     NzIconModule,
+    NzSpinModule,
     TranslateModule,
     ActionComponent
   ]
@@ -225,6 +225,8 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
   startSolving(): void {
     this.phase = 'running';
     this.running = true;
+    this.cd.detectChanges();
+
     this.sub = this.solver
         .solve(
           this.recipe,
@@ -237,25 +239,27 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
         )
         .subscribe({
           next: ({ progress, result, reliablity }) => {
-            console.log('[SolverPopupComponent] event received', { progress, result });
             if (progress) {
+              console.log('[SolverPopupComponent] Progress Result: ', progress);
               this.depth = progress.depth;
               this.bestQuality = progress.bestQuality;
               this.bestSuccess = progress.bestSuccess;
               this.qualityComplete = progress.qualityComplete;
+              this.cd.markForCheck();
             } 
             if (result) {
               this.resultActions = result;
               this.reliablity = reliablity;
               this.running = false;
               this.phase = 'done';
+              this.cd.markForCheck();
             }
-            this.cd.markForCheck();
           },
           error: (err) => {
             this.error = true;
             this.errorMessage = err?.message ?? String(err);
             this.running = false;
+            console.error('[SolverPopupComponent] Progress Error: ', err);
             this.cd.markForCheck();
           }
         });
@@ -264,11 +268,6 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
   /** Closes the modal, returning the found rotation to the caller (e.g. the simulator) */
   apply(): void {
     this.modalRef.close(this.resultActions);
-  }
-
-  /** Formats the quality progress bar label as "current / target" */
-  progressFormat(): () => string {
-    return () => `${this.bestQuality} / ${this.recipe.quality}`;
   }
 
   ngOnDestroy(): void {

--- a/apps/client/src/app/pages/simulator/model/action-category.ts
+++ b/apps/client/src/app/pages/simulator/model/action-category.ts
@@ -1,0 +1,6 @@
+import { CraftingAction } from "@ffxiv-teamcraft/simulator";
+
+export interface ActionCategory {
+  titleKey: string;
+  actions: CraftingAction[];
+}

--- a/apps/client/src/app/pages/simulator/model/solver-core.ts
+++ b/apps/client/src/app/pages/simulator/model/solver-core.ts
@@ -83,6 +83,10 @@ export function runSolver(input: SolverInput, onProgress?: (p: SolverProgress) =
     shouldUseSpecialistCommands = false } = input;
   const startTime = performance.now();
 
+  const enabledActionNames = input.enabledActionNames
+    ? new Set(input.enabledActionNames)
+    : null;
+
   /**
    * Determines whether a given action is allowed to be used by the solver, based on
    * the Cosmic Exploration / Specialist opt-in flagss and the crafter's specialist status
@@ -91,10 +95,10 @@ export function runSolver(input: SolverInput, onProgress?: (p: SolverProgress) =
    */
   const isActionAllowed = (action: CraftingAction): boolean => {
     const name = (action as any).constructor?.name;
-    if (COSMIC_EXPLORATION_ACTION_NAMES.has(name))
-      return shouldUseCosmicExploration;
-    if (SPECIALIST_ACTION_NAMES.has(name))
-      return shouldUseSpecialistCommands && !!stats.specialist;
+    if (enabledActionNames)
+      return enabledActionNames.has(name);
+    if (COSMIC_EXPLORATION_ACTION_NAMES.has(name)) return shouldUseCosmicExploration;
+    if (SPECIALIST_ACTION_NAMES.has(name)) return shouldUseSpecialistCommands && !!stats.specialist;
     return true;
   }
 

--- a/apps/client/src/app/pages/simulator/model/solver-input.ts
+++ b/apps/client/src/app/pages/simulator/model/solver-input.ts
@@ -22,13 +22,24 @@ export interface SolverInput {
   maxSteps: number;
   /** Wall-clock time budget for the search in milliseconds */
   maxComputeMs: number;
+
   /**
+   * Explicit set of allowed action class names, typically produced by the solver
+   * popup's action-selection step. When provided, this is authorative and only
+   * actions whose class name is included, are considered by the search - the
+   * 'shouldUseCosmicExploration' / 'shouldUseSpecialistCommands' flags are ignored.
+   */
+  enabledActionNames?: string[] | Set<string>;
+
+  /**
+   * @deprecated
    * Whether Cosmic Exploration-only actions (e.g. Stellar Steady Hand, Material Miracle)
    * may be used by the solver. Defaults to false. These actions are not available for most
    * recipes and should not be suggested unless the caller explicitly opts in
    */
   shouldUseCosmicExploration?: boolean;
   /**
+   * @deprecated
    * Whether Specialist-only actions (e.g. Heart and Soul) may be used by the solver. This
    * flag alone is not sufficient - the crafter's stats must also have the 'specialist: true'
    * for this actions to be considered. Defaults to false

--- a/apps/client/src/app/pages/simulator/service/solver.service.ts
+++ b/apps/client/src/app/pages/simulator/service/solver.service.ts
@@ -38,8 +38,8 @@ export class SolverService {
   solve(recipe: Craft, stats: CrafterStats,
     hqIngredients: { id: number; amount: number }[] = [],
     beamWidth = 4000, maxSteps = 45, maxComputeMs = 55000,
-    shouldUseCosmicExploration = false,
-    shouldUseSpecialistCommands = false): Observable<SolverEvent> {
+    enabledActionNames: string[] = []
+  ): Observable<SolverEvent> {
     return new Observable(subscriber => {
       if (typeof Worker === 'undefined') {
         subscriber.error(new Error('Web Workers are not supported in this environment.'));
@@ -85,8 +85,7 @@ export class SolverService {
         beamWidth,
         maxSteps,
         maxComputeMs,
-        shouldUseCosmicExploration,
-        shouldUseSpecialistCommands
+        enabledActionNames
       });
 
       return () => worker.terminate();

--- a/apps/client/src/app/pages/simulator/service/solver.service.ts
+++ b/apps/client/src/app/pages/simulator/service/solver.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from "@angular/core";
+import { inject, Injectable, NgZone } from "@angular/core";
 import { Observable } from "rxjs";
 import { Craft, CrafterStats } from "@ffxiv-teamcraft/simulator";
 import { SettingsService } from "../../../modules/settings/settings.service";
@@ -15,6 +15,7 @@ import { SolverEvent } from '../model/solver-event';
 export class SolverService {
   private settings: SettingsService = inject(SettingsService);
   private simulationService: SimulationService = inject(SimulationService);
+  private zone: NgZone = inject(NgZone);
 
   /**
    * Starts a solver run in a dedicated Web Worker for the given recipe and crafter
@@ -50,23 +51,29 @@ export class SolverService {
       const registry = this.simulationService.getSimulator(this.settings.region).CraftingActionsRegistry;
 
       worker.onmessage = ({ data }) => {
-        if (data.type === 'progress') {
-          subscriber.next({ progress: data.progress });
-        } else if (data.type === 'done') {
-          subscriber.next({
-            result: registry.deserializeRotation(data.serializedActions),
-            reliablity: data.reliablity
-          });
-          subscriber.complete();
-          worker.terminate();
-        } else if (data.type === 'error') {
-          subscriber.error(new Error(data.message));
-        }
+        // Web Worker messages run outside Angular's zone by default, so change
+        // detection would otherwise never be triggered by these updates
+        this.zone.run(() => {
+          if (data.type === 'progress') {
+            subscriber.next({ progress: data.progress });
+          } else if (data.type === 'done') {
+            subscriber.next({
+              result: registry.deserializeRotation(data.serializedActions),
+              reliablity: data.reliablity
+            });
+            subscriber.complete();
+            worker.terminate();
+          } else if (data.type === 'error') {
+            subscriber.error(new Error(data.message));
+          }
+        });
       };
 
       worker.onerror = err => {
-        subscriber.error(err);
-        worker.terminate();
+        this.zone.run(() => {
+          subscriber.error(err);
+          worker.terminate();
+        });
       };
 
       worker.postMessage({

--- a/apps/client/src/app/pages/simulator/service/solver.service.ts
+++ b/apps/client/src/app/pages/simulator/service/solver.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable, NgZone } from "@angular/core";
+import { ApplicationRef, inject, Injectable, NgZone } from "@angular/core";
 import { Observable } from "rxjs";
 import { Craft, CrafterStats } from "@ffxiv-teamcraft/simulator";
 import { SettingsService } from "../../../modules/settings/settings.service";
@@ -16,6 +16,7 @@ export class SolverService {
   private settings: SettingsService = inject(SettingsService);
   private simulationService: SimulationService = inject(SimulationService);
   private zone: NgZone = inject(NgZone);
+  private appRef: ApplicationRef = inject(ApplicationRef);
 
   /**
    * Starts a solver run in a dedicated Web Worker for the given recipe and crafter

--- a/apps/client/src/app/pages/simulator/service/solver.worker.ts
+++ b/apps/client/src/app/pages/simulator/service/solver.worker.ts
@@ -41,8 +41,7 @@ addEventListener('message', ({ data }) => {
       beamWidth: data.beamWidth,
       maxSteps: data.maxSteps,
       maxComputeMs: data.maxComputeMs,
-      shouldUseCosmicExploration: data.shouldUseCosmicExploration,
-      shouldUseSpecialistCommands: data.shouldUseSpecialistCommands
+      enabledActionNames: data.enabledActionNames
     }, progress => {
       postMessage({ type: 'progress', progress });
     });

--- a/apps/client/src/assets/i18n/de-DE.json
+++ b/apps/client/src/assets/i18n/de-DE.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "Eine valide Rotation wurde gefunden, optimiere...",
       "Done": "Rotation fertig",
       "Apply": "Nutze diese Rotation",
-      "Quality_maxed": "Maximale Qualität erreicht"
+      "Quality_maxed": "Maximale Qualität erreicht",
+      "Select_actions_hint": "Wähle die Aktionen aus, die für den Löser genutzt werden sollen",
+      "Start": "Beginne Lösen"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Community-Rotationen",

--- a/apps/client/src/assets/i18n/de-DE.json
+++ b/apps/client/src/assets/i18n/de-DE.json
@@ -1188,7 +1188,8 @@
       "Apply": "Nutze diese Rotation",
       "Quality_maxed": "Maximale Qualität erreicht",
       "Select_actions_hint": "Wähle die Aktionen aus, die für den Löser genutzt werden sollen",
-      "Start": "Beginne Lösen"
+      "Start": "Beginne Lösen",
+      "Searching_indeterminate": "Löse die Rotation... es kann bis zu einer Minute dauern, bis eine Lösung erscheint. Bitte schließe das Fenster nicht."
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Community-Rotationen",

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -1194,7 +1194,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Community rotations",

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -1196,7 +1196,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Community rotations",

--- a/apps/client/src/assets/i18n/es-ES.json
+++ b/apps/client/src/assets/i18n/es-ES.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Rotaciones de la comunidad",

--- a/apps/client/src/assets/i18n/es-ES.json
+++ b/apps/client/src/assets/i18n/es-ES.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Rotaciones de la comunidad",

--- a/apps/client/src/assets/i18n/fr-FR.json
+++ b/apps/client/src/assets/i18n/fr-FR.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Rotations communautaires",

--- a/apps/client/src/assets/i18n/fr-FR.json
+++ b/apps/client/src/assets/i18n/fr-FR.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Rotations communautaires",

--- a/apps/client/src/assets/i18n/hr-HR.json
+++ b/apps/client/src/assets/i18n/hr-HR.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Community rotations",

--- a/apps/client/src/assets/i18n/hr-HR.json
+++ b/apps/client/src/assets/i18n/hr-HR.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Community rotations",

--- a/apps/client/src/assets/i18n/ja-JP.json
+++ b/apps/client/src/assets/i18n/ja-JP.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "コミュニティースキル回し",

--- a/apps/client/src/assets/i18n/ja-JP.json
+++ b/apps/client/src/assets/i18n/ja-JP.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "コミュニティースキル回し",

--- a/apps/client/src/assets/i18n/ko-KR.json
+++ b/apps/client/src/assets/i18n/ko-KR.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "커뮤니티 로테이션",

--- a/apps/client/src/assets/i18n/ko-KR.json
+++ b/apps/client/src/assets/i18n/ko-KR.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "커뮤니티 로테이션",

--- a/apps/client/src/assets/i18n/nl-NL.json
+++ b/apps/client/src/assets/i18n/nl-NL.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Community rotations",

--- a/apps/client/src/assets/i18n/nl-NL.json
+++ b/apps/client/src/assets/i18n/nl-NL.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Community rotations",

--- a/apps/client/src/assets/i18n/pt-BR.json
+++ b/apps/client/src/assets/i18n/pt-BR.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Rotações da comunidade",

--- a/apps/client/src/assets/i18n/pt-BR.json
+++ b/apps/client/src/assets/i18n/pt-BR.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Rotações da comunidade",

--- a/apps/client/src/assets/i18n/pt-PT.json
+++ b/apps/client/src/assets/i18n/pt-PT.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Community rotations",

--- a/apps/client/src/assets/i18n/pt-PT.json
+++ b/apps/client/src/assets/i18n/pt-PT.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Community rotations",

--- a/apps/client/src/assets/i18n/ru-RU.json
+++ b/apps/client/src/assets/i18n/ru-RU.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Ротации сообщества",

--- a/apps/client/src/assets/i18n/ru-RU.json
+++ b/apps/client/src/assets/i18n/ru-RU.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "Ротации сообщества",

--- a/apps/client/src/assets/i18n/zh-CN.json
+++ b/apps/client/src/assets/i18n/zh-CN.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "共享手法",

--- a/apps/client/src/assets/i18n/zh-CN.json
+++ b/apps/client/src/assets/i18n/zh-CN.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "共享手法",

--- a/apps/client/src/assets/i18n/zh-TW.json
+++ b/apps/client/src/assets/i18n/zh-TW.json
@@ -1186,7 +1186,9 @@
       "Valid_rotation_found": "A valid rotation has been found, still optimizing…",
       "Done": "Solver finished",
       "Apply": "Use this rotation",
-      "Quality_maxed": "Max quality reached"
+      "Quality_maxed": "Max quality reached",
+      "Select_actions_hint": "Select the Actions, that should be used for the Solver",
+      "Start": "Start Solving"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "社群工序",

--- a/apps/client/src/assets/i18n/zh-TW.json
+++ b/apps/client/src/assets/i18n/zh-TW.json
@@ -1188,7 +1188,8 @@
       "Apply": "Use this rotation",
       "Quality_maxed": "Max quality reached",
       "Select_actions_hint": "Select the Actions, that should be used for the Solver",
-      "Start": "Start Solving"
+      "Start": "Start Solving",
+      "Searching_indeterminate": "Solving your rotation… this can take up to a minute, please don't close this window"
     },
     "COMMUNITY_ROTATIONS": {
       "Title": "社群工序",


### PR DESCRIPTION
Since there were some Problems with the initial auto-solver feature, I implemented a chooser dialog, where the user can choose, which Commands they want to be used in the solver.

The Popup is now divided in three stages:
- selection: Here the User can choose which Commands they want to include/exclude in the Solver. The Solving only starts with the selected ones (Cosmic Exploration and Specialist Commands are deactivated at default - Level Locking is also implemented, so it is only possible to use Commands, that are available for your Crafter-Level) and just used them (tested with multiple configurations, even with deactivating some "surfire" buffs and commands that appeared in every rotation and also on cosmic recipes - it is now possible to even fail the simulation, if there are too many deactivated Commands)
- running: This is the actual solving step. Since there were some Issues with the "old" Live-Progress, I opted to a more simple Version with a simple Info Text, prompting the user to wait up to one minute (the Hardcoded Solving Time Limit)
- done: The final Result. It will show the reliability report including the progress percentatge and the quality percentage. Also it shows the final rotation and the option to apply the rotation into the Simulator, so it can be used to generate Macros.

These changes should remove the most common Problems with unwanted commands used in the Solving process and increase the users comfort with chossing the Commands, they are fine with.

For future improvements there could be the option to save the chosen Commands, so the user don't have to chosse them every time the popup opens