### PR TITLE
fix (simulator): Actions for Solver now choosable

### DIFF
--- a/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
+++ b/apps/client/src/app/pages/simulator/components/solver-popup/solver-popup.component.ts
@@ -20,13 +20,13 @@ import { NzSpinModule } from "ng-zorro-antd/spin";
  * actions, excluded from the default selection since they only apply to a small
  * subset of recipes. Kept in sync with the same list in `solver-core.ts`.
  */
-const COSMIC_EXPLORATION_ACTION_NAMES = new Set<string>(['MaterialMiracle2', 'StellarSteadyHand2']);
+const COSMIC_EXPLORATION_ACTION_IDS = new Set<number>([41269, 46843]); // ['MaterialMiracle2', 'StellarSteadyHand2']
 
 /**
  * Class names of Specialist-only actions, excluded from the default selection.
  * Kept in sync with the same list in `solver-core.ts`.
  */
-const SPECIALIST_ACTION_NAMES = new Set<string>(['CarefulObservation2', 'HeartAndSoul2', 'QuickInnovation2']);
+const SPECIALIST_ACTION_IDs = new Set<number>([100395, 100419, 100459]); // ['CarefulObservation2', 'HeartAndSoul2', 'QuickInnovation2']
 
 /**
  * Class names of actions, that are technically safe by the recipe's starting-state
@@ -34,9 +34,7 @@ const SPECIALIST_ACTION_NAMES = new Set<string>(['CarefulObservation2', 'HeartAn
  * used reiably in practice. Excluded from the default selection, but still manually selectable
  * by the user
  */
-const DEFAULT_EXCLUDED_UNRELIABLE_ACTION_NAMES = new Set<string>([
-  'TricksOfTheTrade2'
-]);
+const DEFAULT_EXCLUDED_UNRELIABLE_ACTION_IDS = new Set<number>([100371]); // ['TricksOfTheTrade2']
 
 /** The three high-level phases the popup walks through. */
 type SolverPhase = 'selection' | 'running' | 'done';
@@ -88,7 +86,7 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
   /** Actions grouped by category for the selection grid, build in {@link ngOnInit} */
   categories: ActionCategory[] = [];
   /** Class names of actions the user has enabled for the solver to use */
-  selectedActionNames = new Set<string>()
+  selectedActionIds = new Set<number>()
 
   /** Whether the solver is currently still searching */
   running = true;
@@ -166,21 +164,20 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
    */
   private initializeDefaultSelection(): void {
     const sim = new this.simulator.Simulation(this.recipe, [], this.stats, this.hqIngredients);
-    const baselineResult = sim.run(true, Infinity, true);
-    const baselineSimulation = baselineResult.simulation;
+    const baselineSimulation = sim.run(true, Infinity, true).simulation;
     
     for (const category of this.categories) {
       for (const action of category.actions) {
         if (this.isLevelLocked(action)) continue;
 
-        const name = this.actionName(action);
-        if (COSMIC_EXPLORATION_ACTION_NAMES.has(name)) continue;
-        if (SPECIALIST_ACTION_NAMES.has(name)) continue;
-        if (DEFAULT_EXCLUDED_UNRELIABLE_ACTION_NAMES.has(name)) continue;
+        const id = this.actionId(action);
+        if (COSMIC_EXPLORATION_ACTION_IDS.has(id)) continue;
+        if (SPECIALIST_ACTION_IDs.has(id)) continue;
+        if (DEFAULT_EXCLUDED_UNRELIABLE_ACTION_IDS.has(id)) continue;
 
         if ((action as any).getSuccessRate?.(baselineSimulation) < 100) continue;
 
-        this.selectedActionNames.add(name);
+        this.selectedActionIds.add(id);
       }
     }
   }
@@ -201,24 +198,24 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
 
   /** Wheter the given action is currently selected for the solver to use */
   isEnabled(action: CraftingAction): boolean {
-    return this.selectedActionNames.has(this.actionName(action));
+    return this.selectedActionIds.has(this.actionId(action));
   }
 
   /** Toggles an action's inclusion in the solver's candidate pool. No-op for level-locked */
   toggleAction(action: CraftingAction): void {
     if (this.isLevelLocked(action)) return;
-    const name = this.actionName(action);
-    if (this.selectedActionNames.has(name))
-      this.selectedActionNames.delete(name);
+    const id = this.actionId(action);
+    if (this.selectedActionIds.has(id))
+      this.selectedActionIds.delete(id);
     else
-      this.selectedActionNames.add(name);
+      this.selectedActionIds.add(id);
 
     this.cd.markForCheck();
   }
 
   /** Returns the name of the Action */
-  private actionName(action: CraftingAction): string {
-    return (action as any).constructor?.name;
+  private actionId(action: CraftingAction): number {
+    return action.getIds()[0];
   }
 
   /** Advances from the selection step to actually running the solver */
@@ -235,7 +232,7 @@ export class SolverPopupComponent extends DialogComponent implements OnInit, OnD
           this.beamWidth,
           this.maxSteps,
           this.maxComputeMs,
-          [...this.selectedActionNames]
+          [...this.selectedActionIds]
         )
         .subscribe({
           next: ({ progress, result, reliablity }) => {

--- a/apps/client/src/app/pages/simulator/model/solver-core.ts
+++ b/apps/client/src/app/pages/simulator/model/solver-core.ts
@@ -4,25 +4,24 @@ import { SolverProgress } from './solver-progress';
 import { Node } from './node';
 
 /**
- * Class names (as reported by `action.constructor.name`) of actions, that are only available
+ * Class Ids (as reported by `action.getIds()[0]`) of actions, that are only available
  * through the Cosmic Exploration content and only applies to specific recipes there. These must never be part
- * of a generated rotation unless the caller explicitly opts in via {@link SolverInput["shouldUseCosmicExploration"]}.
+ * of a generated rotation unless the caller explicitly opts in.
  */
-const COSMIC_EXPLORATION_ACTION_NAMES = new Set<string>([
-  'MaterialMiracle2',
-  'StellarSteadyHand2'
+const COSMIC_EXPLORATION_ACTION_NAMES = new Set<number>([
+  41269, // MaterialMiracle2
+  46843 // StellarSteadyHand2
 ]);
 
 /**
- * Class names of Specialist-only actions. These require both the crafter's "Specialist"
- * flag to be active (see {@link CrafterStats.specialist}) AND the caller opting in
- * via {@link SolverInput["shouldUseSpecialistCommands"]}. Without both conditions, these
- * actions are excluded from the candidate action pool entirely.
+ * Class Ids of Specialist-only actions. These require both the crafter's "Specialist"
+ * flag to be active (see {@link CrafterStats.specialist}) AND the caller opting in.
+ * Without both conditions, these actions are excluded from the candidate action pool entirely.
  */
-const SPECIALIST_ACTION_NAMES = new Set<string>([
-  'CarefulObservation2',
-  'HeartAndSoul2',
-  'QuickInnovation2'
+const SPECIALIST_ACTION_NAMES = new Set<number>([
+  100395, // CarefulObservation2
+  100419, // HeartAndSoul2
+  100459 // QuickInnovation2
 ]);
 
 /**
@@ -30,13 +29,13 @@ const SPECIALIST_ACTION_NAMES = new Set<string>([
  * solver can detet when re-activating a buff would be redundant (i.e. the buff is 
  * already active and not close to expiring).)
  */
-const BUFF_ACTION_TO_BUFF_KEY: Record<string, string> = {
-  Veneration2: 'VENERATION',
-  Innovation2: 'INNOVATION',
-  GreatStrides2: 'GREAT_STRIDES',
-  Manipulation2: 'MANIPULATION',
-  WasteNot2: 'WASTE_NOT',
-  WasteNotII2: 'WASTE_NOT_II'
+const BUFF_ACTION_TO_BUFF_KEY: Record<number, string> = {
+  19297: 'VENERATION',
+  19004: 'INNOVATION',
+  260: 'GREAT_STRIDES',
+  4574: 'MANIPULATION',
+  4631: 'WASTE_NOT',
+  4639: 'WASTE_NOT_II'
 };
 
 /**
@@ -83,8 +82,8 @@ export function runSolver(input: SolverInput, onProgress?: (p: SolverProgress) =
     shouldUseSpecialistCommands = false } = input;
   const startTime = performance.now();
 
-  const enabledActionNames = input.enabledActionNames
-    ? new Set(input.enabledActionNames)
+  const enabledActionIds = input.enabledActionIds
+    ? new Set(input.enabledActionIds)
     : null;
 
   /**
@@ -94,11 +93,11 @@ export function runSolver(input: SolverInput, onProgress?: (p: SolverProgress) =
    * @returns Returns if the action is allowed or not
    */
   const isActionAllowed = (action: CraftingAction): boolean => {
-    const name = (action as any).constructor?.name;
-    if (enabledActionNames)
-      return enabledActionNames.has(name);
-    if (COSMIC_EXPLORATION_ACTION_NAMES.has(name)) return shouldUseCosmicExploration;
-    if (SPECIALIST_ACTION_NAMES.has(name)) return shouldUseSpecialistCommands && !!stats.specialist;
+    const id = action.getIds()[0];
+    if (enabledActionIds)
+      return enabledActionIds.has(id);
+    if (COSMIC_EXPLORATION_ACTION_NAMES.has(id)) return shouldUseCosmicExploration;
+    if (SPECIALIST_ACTION_NAMES.has(id)) return shouldUseSpecialistCommands && !!stats.specialist;
     return true;
   }
 
@@ -110,6 +109,14 @@ export function runSolver(input: SolverInput, onProgress?: (p: SolverProgress) =
     ...registry.getActionsByType(ActionType.OTHER),
     ...registry.getActionsByType(ActionType.CP_RECOVERY)
   ].filter(isActionAllowed);
+
+
+  // Kept in the Code so it is later easier to create a logging for new or changed actions
+  /*console.log('[diagnose] action id/name map:');
+  console.table(candidateActions.map(a => ({
+    id: a.getIds()[0],
+    name: a.constructor.name
+  })));*/
 
   const progressionActions = registry.getActionsByType(ActionType.PROGRESSION).filter(isActionAllowed);
 
@@ -160,7 +167,7 @@ export function runSolver(input: SolverInput, onProgress?: (p: SolverProgress) =
    * @returns Returns true if the action would redundantly re-activate an already active buff, false otherwise
    */
   const isRedundantBuffActivation = (action: CraftingAction, simulation: any): boolean => {
-    const buffKey = BUFF_ACTION_TO_BUFF_KEY[action.constructor?.name];
+    const buffKey = BUFF_ACTION_TO_BUFF_KEY[action.getIds()[0]];
     if (!buffKey) return false;
     const active = findActiveBuff(simulation, buffKey);
     if (!active) return false;

--- a/apps/client/src/app/pages/simulator/model/solver-input.ts
+++ b/apps/client/src/app/pages/simulator/model/solver-input.ts
@@ -29,7 +29,7 @@ export interface SolverInput {
    * actions whose class name is included, are considered by the search - the
    * 'shouldUseCosmicExploration' / 'shouldUseSpecialistCommands' flags are ignored.
    */
-  enabledActionNames?: string[] | Set<string>;
+  enabledActionIds?: number[] | Set<number>;
 
   /**
    * @deprecated

--- a/apps/client/src/app/pages/simulator/service/ActionIdMapping.md
+++ b/apps/client/src/app/pages/simulator/service/ActionIdMapping.md
@@ -1,0 +1,48 @@
+# Action ID Mapping
+
+Because of minifying there is a need to use the IDs of the Actions in the Solver. To prevent the implementation of a Logging Table in the future (maybe needed on x.0 patches),
+here is a table to keep track of the IDs and the corresponding Action Names:
+
+## Table
+
+|id|name|
+|---|---
+|100001|'BasicSynthesis2'|
+|100203|'CarefulSynthesis2'|
+|100427|'PrudentSynthesis2'|
+|100363|'RapidSynthesis2'|
+|100403|'Groundwork2'|
+|100379|'MuscleMemory2'|
+|100315|'IntensiveSynthesis2'|
+|100002|'BasicTouch2'|
+|100004|'StandardTouch2'|
+|100411|'AdvancedTouch2'|
+|100355|'HastyTouch2'|
+|100451|'DaringTouch2'|
+|100339|'ByregotsBlessing2'|
+|100128|'PreciseTouch2'|
+|100227|'PrudentTouch2'|
+|100283|'TrainedEye2'|
+|100299|'PreparatoryTouch2'|
+|100387|'Reflect'|
+|100435|'TrainedFinesse2'|
+|100443|'RefinedTouch2'|
+|4631|'WasteNot2'|
+|4639|'WasteNotII2'|
+|260|'GreatStrides2'|
+|19004|'Innovation2'|
+|19297|'Veneration2'|
+|19012|'FinalAppraisal2'|
+|100459|'QuickInnovation2'|
+|46843|'StellarSteadyHand2'|
+|100003|'MastersMend2'|
+|4574|'Manipulation2'|
+|100467|'ImmaculateMend2'|
+|100475|'TrainedPerfection2'|
+|100010|'Observe2'|
+|100419|'HeartAndSoul2'|
+|100395|'CarefulObservation2'|
+|100323|'DelicateSynthesis2'|
+|-1|'RemoveFinalAppraisal2'|
+|41269|'MaterialMiracle2'|
+|100371|'TricksOfTheTrade2'|

--- a/apps/client/src/app/pages/simulator/service/ActionIdMapping.md
+++ b/apps/client/src/app/pages/simulator/service/ActionIdMapping.md
@@ -6,7 +6,7 @@ here is a table to keep track of the IDs and the corresponding Action Names:
 ## Table
 
 |id|name|
-|---|---
+|---|---|
 |100001|'BasicSynthesis2'|
 |100203|'CarefulSynthesis2'|
 |100427|'PrudentSynthesis2'|

--- a/apps/client/src/app/pages/simulator/service/solver.service.ts
+++ b/apps/client/src/app/pages/simulator/service/solver.service.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, inject, Injectable, NgZone } from "@angular/core";
+import { inject, Injectable, NgZone } from "@angular/core";
 import { Observable } from "rxjs";
 import { Craft, CrafterStats } from "@ffxiv-teamcraft/simulator";
 import { SettingsService } from "../../../modules/settings/settings.service";
@@ -16,7 +16,6 @@ export class SolverService {
   private settings: SettingsService = inject(SettingsService);
   private simulationService: SimulationService = inject(SimulationService);
   private zone: NgZone = inject(NgZone);
-  private appRef: ApplicationRef = inject(ApplicationRef);
 
   /**
    * Starts a solver run in a dedicated Web Worker for the given recipe and crafter
@@ -40,7 +39,7 @@ export class SolverService {
   solve(recipe: Craft, stats: CrafterStats,
     hqIngredients: { id: number; amount: number }[] = [],
     beamWidth = 4000, maxSteps = 45, maxComputeMs = 55000,
-    enabledActionNames: string[] = []
+    enabledActionIds: number[] = []
   ): Observable<SolverEvent> {
     return new Observable(subscriber => {
       if (typeof Worker === 'undefined') {
@@ -93,7 +92,7 @@ export class SolverService {
         beamWidth,
         maxSteps,
         maxComputeMs,
-        enabledActionNames
+        enabledActionIds: enabledActionIds
       });
 
       return () => worker.terminate();

--- a/apps/client/src/app/pages/simulator/service/solver.service.ts
+++ b/apps/client/src/app/pages/simulator/service/solver.service.ts
@@ -18,6 +18,35 @@ export class SolverService {
   private zone: NgZone = inject(NgZone);
 
   /**
+   * Creates the web worker in a way that is safe even when the built worker
+   * script is served from a different origin than the page (CDN). Worker
+   * construction requires same-origin script URLs unconditionally
+   * so instead we fetch the script's source as text ourselves (which IS allowed cross-origin given
+   * permissive CORS headers) and construct the worker from a same-origin `blob:` URL.
+   */
+  private async createWorker(): Promise<Worker> {
+    try {
+      return new Worker(new URL('./solver.worker', import.meta.url), { type: 'module' });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'SecurityError') {
+        const match = /Script at '([^']+)/.exec(err.message);
+        const scriptUrl = match?.[1];
+        if (!scriptUrl) throw err;
+
+        const response = await fetch(scriptUrl);
+        if (!response.ok)
+          throw new Error(`Failed to fetch solver worker script: ${response.status} ${response.statusText}`);
+
+        const source = await response.text();
+        const blob = new Blob([source], { type: 'application/javascript' });
+        const blobUrl = URL.createObjectURL(blob);
+        return new Worker(blobUrl, { type: 'module' });
+      }
+      throw err;
+    }
+  }
+
+  /**
    * Starts a solver run in a dedicated Web Worker for the given recipe and crafter
    * stats, and streams progress updates followed by the final result.
    * 
@@ -43,59 +72,61 @@ export class SolverService {
   ): Observable<SolverEvent> {
     return new Observable(subscriber => {
       if (typeof Worker === 'undefined') {
-        subscriber.error(new Error('Web Workers are not supported in this environment.'));
+        subscriber.error(new Error('Web Workers are not supported in this environment'));
         return;
       }
-
-      const worker = new Worker(new URL('./solver.worker', import.meta.url), { type: 'module' });
+      
       const registry = this.simulationService.getSimulator(this.settings.region).CraftingActionsRegistry;
+      let worker: Worker;
 
-      worker.onmessage = ({ data }) => {
-        // Web Worker messages run outside Angular's zone by default, so change
-        // detection would otherwise never be triggered by these updates
-        this.zone.run(() => {
-          if (data.type === 'progress') {
-            subscriber.next({ progress: data.progress });
-          } else if (data.type === 'done') {
-            subscriber.next({
-              result: registry.deserializeRotation(data.serializedActions),
-              reliablity: data.reliablity
+      this.createWorker()
+        .then(createdWorker => {
+          worker = createdWorker;
+
+          worker.onmessage = ({ data }) => {
+            this.zone.run(() => {
+              if (data.type === 'progress')
+                subscriber.next({ progress: data.progress });
+              else if (data.type === 'done') {
+                subscriber.next({
+                  result: registry.deserializeRotation(data.serializedActions),
+                  reliablity: data.reliablity
+                });
+                subscriber.complete();
+                worker.terminate();
+              }
+              else if (data.type === 'error')
+                subscriber.error(new Error(data.message));
             });
-            subscriber.complete();
+          };
+
+          worker.onerror = err => {
+            this.zone.run(() => subscriber.error(err));
             worker.terminate();
-          } else if (data.type === 'error') {
-            subscriber.error(new Error(data.message));
-          }
-        });
-      };
+          };
 
-      worker.onerror = err => {
-        this.zone.run(() => {
-          subscriber.error(err);
-          worker.terminate();
-        });
-      };
+          worker.postMessage({
+            recipe,
+            stats: {
+              jobId: stats.jobId,
+              craftsmanship: stats.craftsmanship,
+              control: stats._control,
+              cp: stats.cp,
+              specialist: stats.specialist,
+              relicTool: stats.relicTool,
+              level: stats.level,
+              levels: stats.levels
+            },
+            hqIngredients,
+            beamWidth,
+            maxSteps,
+            maxComputeMs,
+            enabledActionIds
+          });
+        })
+        .catch(err => this.zone.run(() => subscriber.error(err)));
 
-      worker.postMessage({
-        recipe,
-        stats: {
-          jobId: stats.jobId,
-          craftsmanship: stats.craftsmanship,
-          control: stats._control,
-          cp: stats.cp,
-          specialist: stats.specialist,
-          relicTool: stats.relicTool,
-          level: stats.level,
-          levels: stats.levels
-        },
-        hqIngredients,
-        beamWidth,
-        maxSteps,
-        maxComputeMs,
-        enabledActionIds: enabledActionIds
-      });
-
-      return () => worker.terminate();
+        return () => worker?.terminate();
     });
   }
 }


### PR DESCRIPTION
The Actions are now working as intended. The original Version used the Names as an Identifier, but because of Minifying in the production build the names got lost and switched to one, big goo. So I switched to use the IDs for the Identifying of the Actions. I tested it with enabling Minifiying on dev and testing it against the electron application. It now works like intended