### PR TITLE
revert(fishing-spot): disabled "fish per hookset" datagrid

### DIFF
--- a/apps/client/src/app/pages/db/fishing-spot/fishing-spot.component.html
+++ b/apps/client/src/app/pages/db/fishing-spot/fishing-spot.component.html
@@ -63,11 +63,11 @@
           [activeFish]="highlightedFish$ | async"
           (activeFishChange)="highlightedFish$.next($event)"
         ></app-fishing-spot-tug-datagrid>
-        <app-fishing-spot-hookset-datagrid
+        <!-- <app-fishing-spot-hookset-datagrid
           fxFlex="1 1 auto"
           [activeFish]="highlightedFish$ | async"
           (activeFishChange)="highlightedFish$.next($event)"
-        ></app-fishing-spot-hookset-datagrid>
+        ></app-fishing-spot-hookset-datagrid> -->
       </div>
       <app-fishing-spot-bite-times
         fxFlex="100"


### PR DESCRIPTION
The "fish per hookset" datagrid has been made redundant. Lure skills added with Dawntrail allow determining fish hooksets directly, so inferring hookset from the database is not necessary. I recommend disabling this component unless and until it can be revamped. I've opened a feature request with more detail regarding this: https://github.com/ffxiv-teamcraft/ffxiv-teamcraft/issues/3303

I checked that the page still renders fine without the datagrid, but I encourage second-opinions if you anticipate the flexbox-layout will be unhappy about losing a box.